### PR TITLE
Allow users to select which components to show

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,6 +82,7 @@ libresplit_sources = files(
     'src/gui/component/title.c',
     'src/gui/component/wr.c',
     'src/gui/component/detailed-timer.c',
+    'src/gui/component/comparison.c',
 )
 
 libresplit_ctl_sources = files(

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 
 extern atomic_bool exit_requested; /*!< Set to 1 when LibreSplit is exiting */
+extern LSComponentAvailable* ls_components;
 
 static void ls_app_init(LSApp* app)
 {
@@ -207,6 +208,7 @@ void ls_app_window_destroy(GtkWidget* widget, gpointer data)
     }
     atomic_store(&auto_splitter_enabled, 0);
     atomic_store(&exit_requested, 1);
+    deinitialize_components();
     // Close any other open application windows (settings, dialogs, etc.)
     GApplication* app = g_application_get_default();
     if (app) {
@@ -373,6 +375,7 @@ static void ls_app_window_init(LSAppWindow* win)
 
     // Create all available components (TODO: change this in the future)
     win->components = NULL;
+    initialize_components();
     for (i = 0; ls_components[i].name != NULL; i++) {
         LSComponent* component = ls_components[i].new();
         if (component) {

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -16,7 +16,6 @@
 #include <sys/stat.h>
 
 extern atomic_bool exit_requested; /*!< Set to 1 when LibreSplit is exiting */
-LSComponentAvailable* ls_components = NULL;
 
 static void ls_app_init(LSApp* app)
 {
@@ -390,6 +389,7 @@ static void ls_app_window_init(LSAppWindow* win)
 
     // Create all available components (TODO: change this in the future)
     win->components = NULL;
+    LSComponentAvailable* ls_components = NULL;
     initialize_components(&ls_components);
     for (i = 0; ls_components[i].name != NULL; i++) {
         LSComponent* component = ls_components[i].new();

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -16,7 +16,7 @@
 #include <sys/stat.h>
 
 extern atomic_bool exit_requested; /*!< Set to 1 when LibreSplit is exiting */
-extern LSComponentAvailable* ls_components;
+LSComponentAvailable* ls_components = NULL;
 
 static void ls_app_init(LSApp* app)
 {
@@ -211,7 +211,6 @@ void ls_app_window_destroy(GtkWidget* widget, gpointer data)
     }
     atomic_store(&auto_splitter_enabled, 0);
     atomic_store(&exit_requested, 1);
-    deinitialize_components();
     // Close any other open application windows (settings, dialogs, etc.)
     GApplication* app = g_application_get_default();
     if (app) {
@@ -391,7 +390,7 @@ static void ls_app_window_init(LSAppWindow* win)
 
     // Create all available components (TODO: change this in the future)
     win->components = NULL;
-    initialize_components();
+    ls_components = initialize_components();
     for (i = 0; ls_components[i].name != NULL; i++) {
         LSComponent* component = ls_components[i].new();
         if (component) {
@@ -405,6 +404,7 @@ static void ls_app_window_init(LSAppWindow* win)
             win->components = g_list_append(win->components, component);
         }
     }
+    free(ls_components);
 
     // NOTE: This always creates an empty footer, no matter how many
     //  ^ "footers" are available, which may give issues with theming

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -390,7 +390,7 @@ static void ls_app_window_init(LSAppWindow* win)
 
     // Create all available components (TODO: change this in the future)
     win->components = NULL;
-    ls_components = initialize_components();
+    initialize_components(&ls_components);
     for (i = 0; ls_components[i].name != NULL; i++) {
         LSComponent* component = ls_components[i].new();
         if (component) {

--- a/src/gui/component/comparison.c
+++ b/src/gui/component/comparison.c
@@ -1,0 +1,121 @@
+/** \file comparison.c
+ *
+ * Implementation of the "Comparing against..." component
+ */
+#include "components.h"
+
+/**
+ * @brief The component representing the current type of comparison
+ */
+typedef struct LSComparison {
+    LSComponent base; /*!< The base struct that is extended */
+    GtkWidget* container; /*!< The container for the comparison labels */
+    GtkWidget* comparison_label; /*!< The label showing the "Comparing against" text */
+    GtkWidget* comparison; /*!< The label showing the current selected comparison */
+} LSComparison;
+extern LSComponentOps ls_comparison_operations;
+
+#define comparison_str "Comparing Against"
+
+/**
+ * Constructor
+ */
+LSComponent* ls_component_comparison_new(void)
+{
+    LSComparison* self;
+
+    self = malloc(sizeof(LSComparison));
+    if (!self) {
+        return NULL;
+    }
+    self->base.ops = &ls_comparison_operations;
+
+    self->container = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    add_class(self->container, "footer"); /* hack */
+    add_class(self->container, "comparison-container");
+    gtk_widget_show(self->container);
+
+    self->comparison_label = gtk_label_new(comparison_str);
+    add_class(self->comparison_label, "comparison-label");
+    gtk_container_add(GTK_CONTAINER(self->container), self->comparison_label);
+
+    self->comparison = gtk_label_new(NULL);
+    add_class(self->comparison, "comparison");
+    gtk_widget_set_halign(self->comparison, GTK_ALIGN_END);
+    gtk_container_add(GTK_CONTAINER(self->container), self->comparison);
+
+    return (LSComponent*)self;
+}
+
+/**
+ * Destructor
+ *
+ * @param self The component to destroy
+ */
+static void comparison_delete(LSComponent* self)
+{
+    free(self);
+}
+
+/**
+ * Returns the Comparison GTK widget.
+ *
+ * @param self The Comparison component itself.
+ * @return The container as a GTK Widget.
+ */
+static GtkWidget* comparison_widget(LSComponent* self)
+{
+    return ((LSComparison*)self)->container;
+}
+
+/**
+ * Function to execute when ls_app_window_show_game is executed.
+ *
+ * @param self_ The Comparison component itself.
+ * @param game The game struct instance.
+ * @param timer The timer instance.
+ */
+static void comparison_show_game(LSComponent* self_,
+    const ls_game* game, const ls_timer* timer)
+{
+    LSComparison* self = (LSComparison*)self_;
+    gtk_widget_set_halign(self->comparison_label, GTK_ALIGN_START);
+    gtk_widget_set_hexpand(self->comparison_label, TRUE);
+    gtk_widget_show(self->comparison);
+    gtk_widget_show(self->comparison_label);
+}
+
+/**
+ * Function to execute when ls_app_window_clear_game is executed.
+ *
+ * @param self_ The best time component itself.
+ */
+static void comparison_clear_game(LSComponent* self_)
+{
+    LSComparison* self = (LSComparison*)self_;
+    gtk_widget_hide(self->comparison_label);
+    gtk_widget_hide(self->comparison);
+}
+
+/**
+ * Function to execute when ls_app_window_draw is executed.
+ *
+ * @param self_ The Comparison component itself.
+ * @param game The game struct instance.
+ * @param timer The timer instance.
+ */
+static void comparison_draw(LSComponent* self_, const ls_game* game,
+    const ls_timer* timer)
+{
+    LSComparison* self = (LSComparison*)self_;
+    // NOTE: [Penaz] [2026-03-01] Placeholder
+    gtk_label_set_text(GTK_LABEL(self->comparison), "Personal Best");
+}
+
+LSComponentOps ls_comparison_operations = {
+    .delete = comparison_delete,
+    .widget = comparison_widget,
+    .show_game = comparison_show_game,
+    .clear_game = comparison_clear_game,
+    .draw = comparison_draw
+};

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -61,7 +61,7 @@ void initialize_components(LSComponentAvailable** ls_components)
                     (*ls_components)[compindex] = ls_available_components[j];
                     compindex++;
                 }
-                continue;
+                break;
             }
         }
     }

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -29,54 +29,41 @@ static LSComponentAvailable ls_available_components[] = {
     { NULL, NULL }
 };
 
-LSComponentAvailable* ls_components;
-
 /**
  * Initializes the array of active components
  * by reading the user settings
  */
-void initialize_components(void)
+LSComponentAvailable* initialize_components(void)
 {
-    SectionInfo* section = NULL;
-    for (size_t i = 0; i < sections_count; i++) {
-        section = (SectionInfo*)&sections[i];
-        if (strcmp(section->name, "components") == 0) {
-            break;
-        }
-    }
-    if (!section) {
-        printf("Cannot find components settings section.");
-        abort();
-    }
-    int components_count = 0;
-    for (size_t i = 0; i < section->count; i++) {
-        ConfigEntry entry = ((ConfigEntry*)section->entries)[i];
+    // Enumerate the active components
+    ComponentsConfig components = cfg.components;
+    int active_components_count = 0;
+    for (size_t i = 0; i < sizeof(components) / sizeof(ConfigEntry); i++) {
+        ConfigEntry entry = ((ConfigEntry*)&components)[i];
         if (entry.value.b) {
-            components_count++;
+            active_components_count++;
         }
     }
-    ls_components = malloc((components_count + 1) * sizeof(LSComponentAvailable));
+    LSComponentAvailable* ls_components = malloc((active_components_count + 1) * sizeof(LSComponentAvailable));
     if (!ls_components) {
         printf("Cannot allocate memory for components");
         abort();
     }
+    // Create the fitted, null-terminated ls_components array, containing the active components
     int compindex = 0;
-    for (size_t i = 0; i < sizeof(section->count); i++) {
-        ConfigEntry entry = ((ConfigEntry*)section->entries)[i];
+    for (size_t i = 0; i < sizeof(components) / sizeof(ConfigEntry); i++) {
+        ConfigEntry entry = ((ConfigEntry*)&components)[i];
         for (size_t j = 0; ls_available_components[j].name != NULL; j++) {
             if (strcmp(ls_available_components[j].name, entry.key) == 0) {
                 if (entry.value.b) {
                     ls_components[compindex] = ls_available_components[j];
                     compindex++;
                 }
+                continue;
             }
         }
     }
     ls_components[compindex].name = NULL;
     ls_components[compindex].new = NULL;
-}
-
-void deinitialize_components()
-{
-    free(ls_components);
+    return ls_components;
 }

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -29,6 +29,10 @@ LSComponentAvailable ls_available_components[] = {
 
 LSComponentAvailable* ls_components;
 
+/**
+ * Initializes the array of active components
+ * by reading the user settings
+ */
 void initialize_components(void)
 {
     SectionInfo* section = NULL;

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -29,7 +29,7 @@ LSComponentAvailable ls_available_components[] = {
 
 LSComponentAvailable* ls_components;
 
-void initialize_components()
+void initialize_components(void)
 {
     SectionInfo* section = NULL;
     for (size_t i = 0; i < sections_count; i++) {
@@ -43,13 +43,13 @@ void initialize_components()
         abort();
     }
     int components_count = 0;
-    for (size_t i = 0; i < sizeof(section->count); i++) {
+    for (size_t i = 0; i < section->count; i++) {
         ConfigEntry entry = ((ConfigEntry*)section->entries)[i];
         if (entry.value.b) {
             components_count++;
         }
     }
-    ls_components = malloc(components_count + 1 * sizeof(LSComponentAvailable));
+    ls_components = malloc((components_count + 1) * sizeof(LSComponentAvailable));
     if (!ls_components) {
         printf("Cannot allocate memory for components");
         abort();

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -27,6 +27,8 @@ LSComponentAvailable ls_available_components[] = {
     { NULL, NULL }
 };
 
+LSComponentAvailable* ls_components;
+
 void initialize_components()
 {
     SectionInfo* section;
@@ -44,10 +46,14 @@ void initialize_components()
         }
     }
     ls_components = malloc(components_count + 1 * sizeof(LSComponentAvailable));
+    if (!ls_components) {
+        printf("Cannot allocate memory for components");
+        abort();
+    }
     int compindex = 0;
     for (size_t i = 0; i < sizeof(section->count); i++) {
         ConfigEntry entry = ((ConfigEntry*)section->entries)[i];
-        for (size_t j = 0; j < sizeof(ls_available_components); j++) {
+        for (size_t j = 0; ls_available_components[j].name != NULL; j++) {
             if (strcmp(ls_available_components[j].name, entry.key) == 0) {
                 ls_components[compindex] = ls_available_components[j];
                 compindex++;

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -47,7 +47,7 @@ void initialize_components(LSComponentAvailable** ls_components)
         }
     }
     *ls_components = malloc((active_components_count + 1) * sizeof(LSComponentAvailable));
-    if (!ls_components) {
+    if (!*ls_components) {
         printf("Cannot allocate memory for components");
         abort();
     }

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -32,8 +32,10 @@ static LSComponentAvailable ls_available_components[] = {
 /**
  * Initializes the array of active components
  * by reading the user settings
+ *
+ * @param[out] ls_components The Array of Activated Components
  */
-LSComponentAvailable* initialize_components(void)
+void initialize_components(LSComponentAvailable** ls_components)
 {
     // Enumerate the active components
     ComponentsConfig components = cfg.components;
@@ -44,7 +46,7 @@ LSComponentAvailable* initialize_components(void)
             active_components_count++;
         }
     }
-    LSComponentAvailable* ls_components = malloc((active_components_count + 1) * sizeof(LSComponentAvailable));
+    *ls_components = malloc((active_components_count + 1) * sizeof(LSComponentAvailable));
     if (!ls_components) {
         printf("Cannot allocate memory for components");
         abort();
@@ -56,14 +58,13 @@ LSComponentAvailable* initialize_components(void)
         for (size_t j = 0; ls_available_components[j].name != NULL; j++) {
             if (strcmp(ls_available_components[j].name, entry.key) == 0) {
                 if (entry.value.b) {
-                    ls_components[compindex] = ls_available_components[j];
+                    (*ls_components)[compindex] = ls_available_components[j];
                     compindex++;
                 }
                 continue;
             }
         }
     }
-    ls_components[compindex].name = NULL;
-    ls_components[compindex].new = NULL;
-    return ls_components;
+    (*ls_components)[compindex].name = NULL;
+    (*ls_components)[compindex].new = NULL;
 }

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -14,6 +14,7 @@ LSComponent* ls_component_prev_segment_new(void);
 LSComponent* ls_component_best_sum_new(void);
 LSComponent* ls_component_pb_new(void);
 LSComponent* ls_component_wr_new(void);
+LSComponent* ls_component_comparison_new(void);
 
 LSComponentAvailable ls_available_components[] = {
     { "title", ls_component_title_new },
@@ -22,6 +23,7 @@ LSComponentAvailable ls_available_components[] = {
     { "detailed_timer", ls_component_detailed_timer_new },
     { "prev_segment", ls_component_prev_segment_new },
     { "best_sum", ls_component_best_sum_new },
+    { "comparison", ls_component_comparison_new },
     { "pb", ls_component_pb_new },
     { "wr", ls_component_wr_new },
     { NULL, NULL }

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -55,8 +55,10 @@ void initialize_components()
         ConfigEntry entry = ((ConfigEntry*)section->entries)[i];
         for (size_t j = 0; ls_available_components[j].name != NULL; j++) {
             if (strcmp(ls_available_components[j].name, entry.key) == 0) {
-                ls_components[compindex] = ls_available_components[j];
-                compindex++;
+                if (entry.value.b) {
+                    ls_components[compindex] = ls_available_components[j];
+                    compindex++;
+                }
             }
         }
     }

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -3,6 +3,8 @@
  * Available Components and related utilities
  */
 #include "components.h"
+#include "src/settings/definitions.h"
+#include <stdlib.h>
 
 LSComponent* ls_component_title_new(void);
 LSComponent* ls_component_splits_new(void);
@@ -13,14 +15,50 @@ LSComponent* ls_component_best_sum_new(void);
 LSComponent* ls_component_pb_new(void);
 LSComponent* ls_component_wr_new(void);
 
-LSComponentAvailable ls_components[] = {
+LSComponentAvailable ls_available_components[] = {
     { "title", ls_component_title_new },
     { "splits", ls_component_splits_new },
-    //    { "timer", ls_component_timer_new },
-    { "detailed-timer", ls_component_detailed_timer_new },
-    { "prev-segment", ls_component_prev_segment_new },
-    { "best-sum", ls_component_best_sum_new },
+    { "timer", ls_component_timer_new },
+    { "detailed_timer", ls_component_detailed_timer_new },
+    { "prev_segment", ls_component_prev_segment_new },
+    { "best_sum", ls_component_best_sum_new },
     { "pb", ls_component_pb_new },
     { "wr", ls_component_wr_new },
     { NULL, NULL }
 };
+
+void initialize_components()
+{
+    SectionInfo* section;
+    for (size_t i = 0; i < sections_count; i++) {
+        section = (SectionInfo*)&sections[i];
+        if (strcmp(section->name, "components") == 0) {
+            break;
+        }
+    }
+    int components_count = 0;
+    for (size_t i = 0; i < sizeof(section->count); i++) {
+        ConfigEntry entry = ((ConfigEntry*)section->entries)[i];
+        if (entry.value.b) {
+            components_count++;
+        }
+    }
+    ls_components = malloc(components_count + 1 * sizeof(LSComponentAvailable));
+    int compindex = 0;
+    for (size_t i = 0; i < sizeof(section->count); i++) {
+        ConfigEntry entry = ((ConfigEntry*)section->entries)[i];
+        for (size_t j = 0; j < sizeof(ls_available_components); j++) {
+            if (strcmp(ls_available_components[j].name, entry.key) == 0) {
+                ls_components[compindex] = ls_available_components[j];
+                compindex++;
+            }
+        }
+    }
+    ls_components[compindex].name = NULL;
+    ls_components[compindex].new = NULL;
+}
+
+void deinitialize_components()
+{
+    free(ls_components);
+}

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -31,12 +31,16 @@ LSComponentAvailable* ls_components;
 
 void initialize_components()
 {
-    SectionInfo* section;
+    SectionInfo* section = NULL;
     for (size_t i = 0; i < sections_count; i++) {
         section = (SectionInfo*)&sections[i];
         if (strcmp(section->name, "components") == 0) {
             break;
         }
+    }
+    if (!section) {
+        printf("Cannot find components settings section.");
+        abort();
     }
     int components_count = 0;
     for (size_t i = 0; i < sizeof(section->count); i++) {

--- a/src/gui/component/components.c
+++ b/src/gui/component/components.c
@@ -16,7 +16,7 @@ LSComponent* ls_component_pb_new(void);
 LSComponent* ls_component_wr_new(void);
 LSComponent* ls_component_comparison_new(void);
 
-LSComponentAvailable ls_available_components[] = {
+static LSComponentAvailable ls_available_components[] = {
     { "title", ls_component_title_new },
     { "splits", ls_component_splits_new },
     { "timer", ls_component_timer_new },

--- a/src/gui/component/components.h
+++ b/src/gui/component/components.h
@@ -40,7 +40,5 @@ typedef struct LSComponentAvailable {
 
 // A NULL-terminated array of all available components
 extern AppConfig cfg;
-extern LSComponentAvailable* ls_components;
 
-void initialize_components();
-void deinitialize_components();
+LSComponentAvailable* initialize_components(void);

--- a/src/gui/component/components.h
+++ b/src/gui/component/components.h
@@ -38,7 +38,7 @@ typedef struct LSComponentAvailable {
 
 // A NULL-terminated array of all available components
 extern AppConfig cfg;
-LSComponentAvailable* ls_components;
+extern LSComponentAvailable* ls_components;
 
 void initialize_components();
 void deinitialize_components();

--- a/src/gui/component/components.h
+++ b/src/gui/component/components.h
@@ -41,4 +41,4 @@ typedef struct LSComponentAvailable {
 // A NULL-terminated array of all available components
 extern AppConfig cfg;
 
-LSComponentAvailable* initialize_components(void);
+void initialize_components(LSComponentAvailable** ls_components);

--- a/src/gui/component/components.h
+++ b/src/gui/component/components.h
@@ -1,5 +1,4 @@
-#ifndef __COMPONENTS_H__
-#define __COMPONENTS_H__
+#pragma once
 
 #include <ctype.h>
 #include <gtk/gtk.h>
@@ -8,6 +7,7 @@
 
 #include "../../timer.h"
 #include "../utils.h"
+#include "src/settings/definitions.h"
 
 typedef struct LSComponentOps LSComponentOps; // forward declaration
 
@@ -37,6 +37,8 @@ typedef struct LSComponentAvailable {
 } LSComponentAvailable;
 
 // A NULL-terminated array of all available components
-extern LSComponentAvailable ls_components[];
+extern AppConfig cfg;
+LSComponentAvailable* ls_components;
 
-#endif /* __COMPONENTS_H__ */
+void initialize_components();
+void deinitialize_components();

--- a/src/settings/definitions.c
+++ b/src/settings/definitions.c
@@ -149,6 +149,12 @@ AppConfig cfg = {
             .value.b = true,
             .desc = "Previous Segment",
         },
+        .comparison = {
+            .key = "comparison",
+            .type = CFG_BOOL,
+            .value.b = false,
+            .desc = "Comparison",
+        },
         .best_sum = {
             .key = "best_sum",
             .type = CFG_BOOL,

--- a/src/settings/definitions.c
+++ b/src/settings/definitions.c
@@ -118,6 +118,56 @@ AppConfig cfg = {
             .desc = "Toggle Always On Top",
         },
     },
+    .components = {
+        .title = {
+            .key = "title",
+            .type = CFG_BOOL,
+            .value.b = true,
+            .desc = "Title Bar",
+        },
+        .splits = {
+            .key = "splits",
+            .type = CFG_BOOL,
+            .value.b = true,
+            .desc = "Split List",
+        },
+        .timer = {
+            .key = "timer",
+            .type = CFG_BOOL,
+            .value.b = false,
+            .desc = "Simple Timer",
+        },
+        .detailed_timer = {
+            .key = "detailed_timer",
+            .type = CFG_BOOL,
+            .value.b = true,
+            .desc = "Detailed Timer",
+        },
+        .prev_segment = {
+            .key = "prev_segment",
+            .type = CFG_BOOL,
+            .value.b = true,
+            .desc = "Previous Segment",
+        },
+        .best_sum = {
+            .key = "best_sum",
+            .type = CFG_BOOL,
+            .value.b = true,
+            .desc = "Best Sum",
+        },
+        .pb = {
+            .key = "pb",
+            .type = CFG_BOOL,
+            .value.b = true,
+            .desc = "Personal Best",
+        },
+        .wr = {
+            .key = "wr",
+            .type = CFG_BOOL,
+            .value.b = true,
+            .desc = "World Record",
+        },
+    },
     .history = {
         .split_file = {
             .key = "split_file",
@@ -149,6 +199,7 @@ AppConfig cfg = {
 const SectionInfo sections[] = {
     { "libresplit", &cfg.libresplit, sizeof(cfg.libresplit) / sizeof(ConfigEntry), true },
     { "keybinds", &cfg.keybinds, sizeof(cfg.keybinds) / sizeof(ConfigEntry), true },
+    { "components", &cfg.components, sizeof(cfg.components) / sizeof(ConfigEntry), true },
     { "history", &cfg.history, sizeof(cfg.history) / sizeof(ConfigEntry), false },
 };
 

--- a/src/settings/definitions.h
+++ b/src/settings/definitions.h
@@ -56,10 +56,22 @@ typedef struct HistoryConfig {
     ConfigEntry auto_splitter_file;
 } HistoryConfig;
 
+typedef struct ComponentsConfig {
+    ConfigEntry title;
+    ConfigEntry splits;
+    ConfigEntry timer;
+    ConfigEntry detailed_timer;
+    ConfigEntry prev_segment;
+    ConfigEntry best_sum;
+    ConfigEntry pb;
+    ConfigEntry wr;
+} ComponentsConfig;
+
 typedef struct AppConfig {
     LibreSplitConfig libresplit;
     KeybindConfig keybinds;
     HistoryConfig history;
+    ComponentsConfig components;
 } AppConfig;
 
 /* For each section we point at the first `ConfigEntry` member inside the

--- a/src/settings/definitions.h
+++ b/src/settings/definitions.h
@@ -63,6 +63,7 @@ typedef struct ComponentsConfig {
     ConfigEntry detailed_timer;
     ConfigEntry prev_segment;
     ConfigEntry best_sum;
+    ConfigEntry comparison;
     ConfigEntry pb;
     ConfigEntry wr;
 } ComponentsConfig;


### PR DESCRIPTION
**Rationale:** Allows limited customization of the components shown on the LibreSplit main screen.

Tries to allow the user to select which components to view via the settings screen.

~The code is ugly, compiles but segfaults/iotraps 9 times out of 10.~

Fixes #267 ~if it ever will work~. Fixes #302 too, I think.

Help is very much appreciated.