### PR TITLE
Make sig_scan's "get_memory_regions" use the maps.c functions and maps cache

### DIFF
--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -1,6 +1,7 @@
 #include "process.h"
 
 #include "../utils.h"
+#include "src/lasr/maps/maps.h"
 
 #include <stdatomic.h>
 #include <stdio.h>
@@ -36,6 +37,9 @@ void stock_process_id(const char* pid_command)
 {
     char pid_output[PATH_MAX + 100];
     pid_output[0] = '\0';
+
+    // We just started a new process monitoring, we may want to clean up a stale cache
+    maps_clearCache();
 
     while (atomic_load(&auto_splitter_enabled)) {
         execute_command(pid_command, pid_output);

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -1,6 +1,7 @@
 #include "signature.h"
 
 #include "../utils.h"
+#include "src/lasr/maps/maps.h"
 
 #include <fcntl.h>
 #include <inttypes.h>
@@ -36,52 +37,18 @@ void log_error(const char* format, ...)
 /**
  * Gets all the memory regions of a certain PID
  *
- * @param[in] pid The ID of the process to get the memory regions of
  * @param[in] count A pointer to a counter onto where to store the number of regions
  *
  * @return A dinamically allocated array of ProcessMap that have been found
  */
-ProcessMap* get_memory_regions(pid_t pid, int* count)
+ProcessMap* get_memory_regions(int* count)
 {
-    // TODO: Convert this function to use maps.c functions
-    char maps_path[256];
-    if (snprintf(maps_path, sizeof(maps_path), "/proc/%d/maps", pid) < 0) {
-        HANDLE_ERROR("Failed to create maps path");
+    if (maps_cache == NULL) {
+        *count = maps_getAll();
+    } else {
+        *count = maps_cache_size;
     }
-
-    FILE* maps_file = fopen(maps_path, "r");
-    if (!maps_file) {
-        HANDLE_ERROR("Failed to open maps file");
-    }
-
-    ProcessMap* regions = NULL;
-    int capacity = 0;
-    *count = 0;
-
-    char line[256];
-    while (fgets(line, sizeof(line), maps_file)) {
-        if (*count >= capacity) {
-            capacity = capacity == 0 ? 10 : capacity * 2;
-            ProcessMap* temp = realloc(regions, capacity * sizeof(ProcessMap));
-            if (!temp) {
-                free(regions);
-                fclose(maps_file);
-                HANDLE_ERROR("Failed to allocate memory for regions");
-            }
-            regions = temp;
-        }
-
-        uintptr_t start, end;
-        if (sscanf(line, "%" SCNxPTR "-%" SCNxPTR, &start, &end) != 2) {
-            continue; // Skip lines that don't match the expected format
-        }
-        regions[*count].start = start;
-        regions[*count].end = end;
-        (*count)++;
-    }
-
-    fclose(maps_file);
-    return regions;
+    return maps_cache;
 }
 
 /**
@@ -213,7 +180,7 @@ int perform_sig_scan(lua_State* L)
     }
 
     int regions_count = 0;
-    ProcessMap* regions = get_memory_regions(p_pid, &regions_count);
+    ProcessMap* regions = get_memory_regions(&regions_count);
     if (!regions) {
         free(pattern);
         log_error("Failed to get memory regions");
@@ -227,7 +194,6 @@ int perform_sig_scan(lua_State* L)
         uint8_t* buffer = malloc(region_size);
         if (!buffer) {
             free(pattern);
-            free(regions);
             log_error("Failed to allocate memory for region buffer");
             lua_pushnil(L);
             return 1;
@@ -251,7 +217,6 @@ int perform_sig_scan(lua_State* L)
 
                 free(buffer);
                 free(pattern);
-                free(regions);
 
                 lua_pushnumber(L, result);
                 return 1;
@@ -262,7 +227,6 @@ int perform_sig_scan(lua_State* L)
     }
 
     free(pattern);
-    free(regions);
 
     // No match found
     log_error("No match found for the given signature");

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -1,7 +1,7 @@
 #include "signature.h"
 
+#include "../maps/maps.h"
 #include "../utils.h"
-#include "src/lasr/maps/maps.h"
 
 #include <fcntl.h>
 #include <inttypes.h>

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -35,7 +35,7 @@ void log_error(const char* format, ...)
 }
 
 /**
- * Gets all the memory regions of a certain PID
+ * Gets all the memory regions of the monitored process
  *
  * @param[in] count A pointer to a counter onto where to store the number of regions
  *
@@ -43,7 +43,8 @@ void log_error(const char* format, ...)
  */
 ProcessMap* get_memory_regions(size_t* count)
 {
-    if (maps_cache == NULL) {
+    if (maps_cache == NULL || maps_cache_cycles == 0) {
+        // maps_getAll clears the cache automatically before fillup
         *count = maps_getAll();
     } else {
         *count = maps_cache_size;
@@ -155,14 +156,12 @@ int perform_sig_scan(lua_State* L)
 {
     if (lua_gettop(L) != 2) {
         log_error("Invalid number of arguments: expected 2 (signature, offset)");
-        lua_pushnil(L);
-        return 1;
+        goto sigscan_fail;
     }
 
     if (!lua_isstring(L, 1) || !lua_isnumber(L, 2)) {
         log_error("Invalid argument types: expected (string, number)");
-        lua_pushnil(L);
-        return 1;
+        goto sigscan_fail;
     }
 
     pid_t p_pid = process.pid;
@@ -172,16 +171,14 @@ int perform_sig_scan(lua_State* L)
     // Validate signature string
     if (strlen(signature) == 0) {
         log_error("Signature string cannot be empty");
-        lua_pushnil(L);
-        return 1;
+        goto sigscan_fail;
     }
 
     size_t pattern_length;
     uint16_t* pattern = convert_signature(signature, &pattern_length);
     if (!pattern) {
         log_error("Failed to convert signature");
-        lua_pushnil(L);
-        return 1;
+        goto sigscan_fail;
     }
 
     size_t regions_count = 0;
@@ -189,8 +186,7 @@ int perform_sig_scan(lua_State* L)
     if (!regions) {
         free(pattern);
         log_error("Failed to get memory regions");
-        lua_pushnil(L);
-        return 1;
+        goto sigscan_fail;
     }
 
     for (size_t i = 0; i < regions_count; i++) {
@@ -200,8 +196,7 @@ int perform_sig_scan(lua_State* L)
         if (!buffer) {
             free(pattern);
             log_error("Failed to allocate memory for region buffer");
-            lua_pushnil(L);
-            return 1;
+            goto sigscan_fail;
         }
 
         if (!validate_process_memory(p_pid, region.start, buffer, region_size)) {
@@ -223,6 +218,9 @@ int perform_sig_scan(lua_State* L)
                 free(buffer);
                 free(pattern);
 
+                if (maps_cache_cycles == 0) {
+                    maps_clearCache();
+                }
                 lua_pushnumber(L, result);
                 return 1;
             }
@@ -235,6 +233,10 @@ int perform_sig_scan(lua_State* L)
 
     // No match found
     log_error("No match found for the given signature");
+sigscan_fail:
+    if (maps_cache_cycles == 0) {
+        maps_clearCache();
+    }
     lua_pushnil(L);
     return 1;
 }

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -41,7 +41,7 @@ void log_error(const char* format, ...)
  *
  * @return A dinamically allocated array of ProcessMap that have been found
  */
-ProcessMap* get_memory_regions(int* count)
+ProcessMap* get_memory_regions(size_t* count)
 {
     if (maps_cache == NULL) {
         *count = maps_getAll();
@@ -184,7 +184,7 @@ int perform_sig_scan(lua_State* L)
         return 1;
     }
 
-    int regions_count = 0;
+    size_t regions_count = 0;
     ProcessMap* regions = get_memory_regions(&regions_count);
     if (!regions) {
         free(pattern);
@@ -193,7 +193,7 @@ int perform_sig_scan(lua_State* L)
         return 1;
     }
 
-    for (int i = 0; i < regions_count; i++) {
+    for (size_t i = 0; i < regions_count; i++) {
         ProcessMap region = regions[i];
         ssize_t region_size = region.end - region.start;
         uint8_t* buffer = malloc(region_size);

--- a/src/lasr/functions/signature.h
+++ b/src/lasr/functions/signature.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "src/lasr/utils.h"
 #include <lua.h>
+
+extern ProcessMap* maps_cache;
+extern size_t maps_cache_size;
 
 int perform_sig_scan(lua_State* L);

--- a/src/lasr/maps/maps.c
+++ b/src/lasr/maps/maps.c
@@ -1,6 +1,7 @@
 #include "maps.h"
 
 #include "src/lasr/utils.h"
+#include "src/logging.h"
 
 #include <fcntl.h>
 #include <linux/fs.h>
@@ -214,24 +215,30 @@ static size_t maps_getAll_legacy(void)
 {
     char path[22]; // 22 is the maximum length the path can be (strlen("/proc/4294967296/maps"))
 
-    snprintf(path, sizeof(path), "/proc/%d/maps", process.pid);
+    if (snprintf(path, sizeof(path), "/proc/%d/maps", process.pid) < 0) {
+        LOG_ERR("Failed to create maps path");
+        return 0;
+    }
 
     FILE* f = fopen(path, "r");
 
-    if (f) {
-        char current_line[PATH_MAX + 100];
-        maps_clearCache();
-        while (fgets(current_line, sizeof(current_line), f) != NULL) {
-            ProcessMap map;
-            if (maps_parseMapsLine(current_line, &map)) {
-                append_entry(map);
-            } else {
-                printf("Failed to parse maps line: %s\n", current_line);
-            }
-        }
-        fclose(f);
-        maps_cache = maps_flatten(&maps_cache_size);
+    if (!f) {
+        LOG_ERR("Failed to open maps file");
+        return 0;
     }
+
+    char current_line[PATH_MAX + 100];
+    maps_clearCache();
+    while (fgets(current_line, sizeof(current_line), f) != NULL) {
+        ProcessMap map;
+        if (maps_parseMapsLine(current_line, &map)) {
+            append_entry(map);
+        } else {
+            printf("Failed to parse maps line: %s\n", current_line);
+        }
+    }
+    fclose(f);
+    maps_cache = maps_flatten(&maps_cache_size);
     return maps_cache_size;
 }
 

--- a/src/lasr/maps/maps.c
+++ b/src/lasr/maps/maps.c
@@ -206,11 +206,11 @@ static bool maps_parseMapsLine(const char* line, ProcessMap* map)
 {
     uint64_t size;
     char mode[8];
-    unsigned long offset;
-    unsigned int major_id, minor_id, node_id;
+    unsigned long offset, node_id;
+    unsigned int major_id, minor_id;
 
     // Thank you kernel source code
-    int sscanf_res = sscanf(line, "%lx-%lx %7s %lx %u:%u %u %" STR(PATH_MAX) "[^\n]", &map->start,
+    int sscanf_res = sscanf(line, "%lx-%lx %7s %lx %x:%x %lu %" STR(PATH_MAX) "[^\n]", &map->start,
         &map->end, mode, &offset, &major_id,
         &minor_id, &node_id, map->name);
     if (!sscanf_res)
@@ -245,8 +245,11 @@ static size_t maps_getAll_legacy(void)
 
     char current_line[PATH_MAX + 100];
     maps_clearCache();
+    // XXX: [Penaz] [2026-09-10] Is it possible for /proc/pid/maps to generate a line longer
+    // ^ than 4096 (+ 100 chars of "padding") characters? If we ever run into buffer size issues
+    // ^ it might be worth looking into using getline()
     while (fgets(current_line, sizeof(current_line), f) != NULL) {
-        ProcessMap map;
+        ProcessMap map = { 0 };
         if (maps_parseMapsLine(current_line, &map)) {
             append_entry(map);
         } else {

--- a/src/lasr/maps/maps.c
+++ b/src/lasr/maps/maps.c
@@ -213,8 +213,12 @@ static bool maps_parseMapsLine(const char* line, ProcessMap* map)
     int sscanf_res = sscanf(line, "%lx-%lx %7s %lx %x:%x %lu %" STR(PATH_MAX) "[^\n]", &map->start,
         &map->end, mode, &offset, &major_id,
         &minor_id, &node_id, map->name);
-    if (!sscanf_res)
+    // Here we only allow the map name to be empty, anything else should return show a
+    // parsing failure
+    if (sscanf_res < 7) {
+        LOG_DEBUGF("Cannot fully parse the maps line: %s", line);
         return false;
+    }
 
     // Calculate the map size
     size = map->end - map->start;

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -31,7 +31,7 @@ typedef struct ProcessMap {
     uintptr_t start;
     uintptr_t end;
     uintptr_t size;
-    char name[PATH_MAX];
+    char name[PATH_MAX + 100];
 } ProcessMap;
 
 bool restart_auto_splitter(void);

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -31,7 +31,7 @@ typedef struct ProcessMap {
     uintptr_t start;
     uintptr_t end;
     uintptr_t size;
-    char name[PATH_MAX + 100];
+    char name[PATH_MAX + 1];
 } ProcessMap;
 
 bool restart_auto_splitter(void);


### PR DESCRIPTION
**Rationale:** Allows `get_memory_regions` to benefit from the maps cache, which trickles down to `sig_scan` too, helping it be a little bit faster.

I had to remove all the `free(regions)` calls to avoid double-free issues on the alias (one from the perform_sig_scan and one from maps_clearCache).

Since get_memory_regions should only read such cache, this should be a safe operation.

Fixes #345 