### PR TITLE
Memory iterator

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,7 @@ libresplit_sources = files(
     # LASR
     'src/lasr/auto-splitter.c',
     'src/lasr/utils.c',
+    'src/lasr/memory_iter/memory_iterator.c',
     'src/lasr/maps/maps.c',
     'src/lasr/functions/bitwise.c',
     'src/lasr/functions/getBaseAddress.c',

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -228,7 +228,6 @@ int perform_sig_scan(lua_State* L)
     int regions_count = 0;
     regions = get_memory_regions(p_pid, &regions_count);
     if (!regions) {
-        free(pattern);
         log_error("Failed to get memory regions");
         lua_pushnil(L);
         ret = 1;

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -257,8 +257,7 @@ int perform_sig_scan(lua_State* L)
                 }
             }
         }
-        free(mem_iter);
-        mem_iter = NULL;
+        mem_iterator_destroy(&mem_iter);
         if (err == 3) {
             // Unreadable map
             continue;
@@ -278,7 +277,7 @@ int perform_sig_scan(lua_State* L)
 cleanup:
     free(pattern);
     pattern = NULL;
-    mem_iterator_destroy(mem_iter);
+    mem_iterator_destroy(&mem_iter);
     free(regions);
     regions = NULL;
     return ret;

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -261,6 +261,10 @@ int perform_sig_scan(lua_State* L)
         }
         free(mem_iter);
         mem_iter = NULL;
+        if (err == 3) {
+            // Unreadable map
+            continue;
+        }
         if (err) {
             log_error("There has been an error in sig_scan: error code %d", err);
             lua_pushnil(L);

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -185,16 +185,23 @@ bool validate_process_memory(pid_t pid, uintptr_t address, void* buffer, size_t 
  */
 int perform_sig_scan(lua_State* L)
 {
+    int ret = 1;
+    MemoryIterator* mem_iter = NULL;
+    uint16_t* pattern = NULL;
+    uint8_t* buffer = NULL;
+    ProcessMap* regions = NULL;
     if (lua_gettop(L) != 2) {
         log_error("Invalid number of arguments: expected 2 (signature, offset)");
         lua_pushnil(L);
-        return 1;
+        ret = 1;
+        goto cleanup;
     }
 
     if (!lua_isstring(L, 1) || !lua_isnumber(L, 2)) {
         log_error("Invalid argument types: expected (string, number)");
         lua_pushnil(L);
-        return 1;
+        ret = 1;
+        goto cleanup;
     }
 
     pid_t p_pid = process.pid;
@@ -205,30 +212,32 @@ int perform_sig_scan(lua_State* L)
     if (strlen(signature) == 0) {
         log_error("Signature string cannot be empty");
         lua_pushnil(L);
-        return 1;
+        ret = 1;
+        goto cleanup;
     }
 
     size_t pattern_length;
-    uint16_t* pattern = convert_signature(signature, &pattern_length);
+    pattern = convert_signature(signature, &pattern_length);
     if (!pattern) {
         log_error("Failed to convert signature");
         lua_pushnil(L);
-        return 1;
+        ret = 1;
+        goto cleanup;
     }
 
     int regions_count = 0;
-    ProcessMap* regions = get_memory_regions(p_pid, &regions_count);
+    regions = get_memory_regions(p_pid, &regions_count);
     if (!regions) {
         free(pattern);
         log_error("Failed to get memory regions");
         lua_pushnil(L);
-        return 1;
+        ret = 1;
+        goto cleanup;
     }
 
     for (int i = 0; i < regions_count; i++) {
         ProcessMap region = regions[i];
-        MemoryIterator* mem_iter = mem_iterator_new(p_pid, region.start, region.end, pattern_length);
-        uint8_t* buffer = NULL;
+        mem_iter = mem_iterator_new(p_pid, region.start, region.end, pattern_length);
         uint8_t err = 0;
         size_t buffer_length;
         while (mem_next(&buffer, &buffer_length, mem_iter, &err)) {
@@ -245,57 +254,34 @@ int perform_sig_scan(lua_State* L)
                     // the found signature. This should be corrected by readAddress.
                     intptr_t result = (mem_iter->cursor + j + offset) - process.base_address;
 
-                    if (buffer) {
-                        free(buffer);
-                        buffer = NULL;
-                    }
-                    if (pattern) {
-                        free(pattern);
-                        pattern = NULL;
-                    }
-                    if (regions) {
-                        free(regions);
-                        regions = NULL;
-                    }
                     lua_pushnumber(L, result);
-                    return 1;
+                    ret = 1;
+                    goto cleanup;
                 }
             }
         }
-        if (buffer) {
-            free(buffer);
-            buffer = NULL;
-        }
-        if (mem_iter) {
-            free(mem_iter);
-            mem_iter = NULL;
-        }
+        free(mem_iter);
+        mem_iter = NULL;
         if (err) {
-            if (pattern) {
-                free(pattern);
-                pattern = NULL;
-            }
-            if (regions) {
-                free(regions);
-                regions = NULL;
-            }
             log_error("There has been an error in sig_scan: error code %d", err);
             lua_pushnil(L);
-            return 1;
+            ret = 1;
+            goto cleanup;
         }
-    }
-
-    if (pattern) {
-        free(pattern);
-        pattern = NULL;
-    }
-    if (regions) {
-        free(regions);
-        regions = NULL;
     }
 
     // No match found
     log_error("No match found for the given signature");
     lua_pushnil(L);
-    return 1;
+    ret = 1;
+cleanup:
+    free(buffer);
+    buffer = NULL;
+    free(pattern);
+    pattern = NULL;
+    free(mem_iter);
+    mem_iter = NULL;
+    free(regions);
+    regions = NULL;
+    return ret;
 }

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -280,7 +280,7 @@ int perform_sig_scan(lua_State* L)
                 free(regions);
                 regions = NULL;
             }
-            log_error("There has been an error in sig_scan: %d", err);
+            log_error("There has been an error in sig_scan: error code %d", err);
             lua_pushnil(L);
             return 1;
         }

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -1,5 +1,6 @@
 #include "signature.h"
 
+#include "../../logging.h"
 #include "../memory_iter/memory_iterator.h"
 #include "../utils.h"
 
@@ -233,9 +234,15 @@ int perform_sig_scan(lua_State* L)
         goto cleanup;
     }
 
+    // Forward initialization of the memory iterator.
+    mem_iter = mem_iterator_new(p_pid, 0, 0, pattern_length);
+
     for (int i = 0; i < regions_count; i++) {
         ProcessMap region = regions[i];
-        mem_iter = mem_iterator_new(p_pid, region.start, region.end, pattern_length);
+        if (!mem_iterator_recycle(&mem_iter, p_pid, region.start, region.end, pattern_length)) {
+            LOG_ERR("Unable to recycle memory iterator, exiting the sig_scan loop");
+            goto cleanup;
+        }
         uint8_t err = 0;
         while (mem_next(mem_iter, &err)) {
             // Now buffer contains the read memory chunk
@@ -257,7 +264,6 @@ int perform_sig_scan(lua_State* L)
                 }
             }
         }
-        mem_iterator_destroy(&mem_iter);
         if (err == 3) {
             // Unreadable map
             continue;

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -1,11 +1,15 @@
 #include "signature.h"
 
+#include "../memory_iter/memory_iterator.h"
 #include "../utils.h"
 
+#include <assert.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <lua.h>
 #include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -223,46 +227,69 @@ int perform_sig_scan(lua_State* L)
 
     for (int i = 0; i < regions_count; i++) {
         ProcessMap region = regions[i];
-        ssize_t region_size = region.end - region.start;
-        uint8_t* buffer = malloc(region_size);
-        if (!buffer) {
-            free(pattern);
-            free(regions);
-            log_error("Failed to allocate memory for region buffer");
+        MemoryIterator* mem_iter = mem_iterator_new(p_pid, region.start, region.end, pattern_length);
+        uint8_t* buffer = NULL;
+        uint8_t err = 0;
+        size_t buffer_length;
+        while (mem_next(&buffer, &buffer_length, mem_iter, &err)) {
+            // Now buffer contains the read memory chunk
+            assert(buffer_length >= pattern_length);
+            for (size_t j = 0; j <= buffer_length - pattern_length; ++j) {
+                if (match_pattern(buffer + j, pattern, pattern_length)) {
+                    // The resulting address is the start of the region
+                    // plus the index of the first byte that matches
+                    // plus the user-set offset, minus the process's base_address
+                    // or a subsequent memory read will read the wrong address or
+                    // go out of memory (due to commit 2b4417f offsetting memory reads)
+                    // So this result might be negative if the main module happens to be after
+                    // the found signature. This should be corrected by readAddress.
+                    intptr_t result = (mem_iter->cursor + j + offset) - process.base_address;
+
+                    if (buffer) {
+                        free(buffer);
+                        buffer = NULL;
+                    }
+                    if (pattern) {
+                        free(pattern);
+                        pattern = NULL;
+                    }
+
+                    lua_pushnumber(L, result);
+                    return 1;
+                }
+            }
+        }
+        if (buffer) {
+            free(buffer);
+            buffer = NULL;
+        }
+        if (mem_iter) {
+            free(mem_iter);
+            mem_iter = NULL;
+        }
+        if (err) {
+            if (pattern) {
+                free(pattern);
+                pattern = NULL;
+            }
+            if (regions) {
+                free(regions);
+                regions = NULL;
+            }
+            log_error("There has been an error in sig_scan: %d", err);
             lua_pushnil(L);
             return 1;
         }
-
-        if (!validate_process_memory(p_pid, region.start, buffer, region_size)) {
-            free(buffer);
-            continue; // Continue to next region
-        }
-
-        for (size_t j = 0; j <= region_size - pattern_length; ++j) {
-            if (match_pattern(buffer + j, pattern, pattern_length)) {
-                // The resulting address is the start of the region
-                // plus the index of the first byte that matches
-                // plus the user-set offset, minus the process's base_address
-                // or a subsequent memory read will read the wrong address or
-                // go out of memory (due to commit 2b4417f offsetting memory reads)
-                // So this result might be negative if the main module happens to be after
-                // the found signature. This should be corrected by readAddress.
-                intptr_t result = (region.start + j + offset) - process.base_address;
-
-                free(buffer);
-                free(pattern);
-                free(regions);
-
-                lua_pushnumber(L, result);
-                return 1;
-            }
-        }
-
-        free(buffer);
     }
 
-    free(pattern);
-    free(regions);
+    if (pattern) {
+        free(pattern);
+        pattern = NULL;
+    }
+    if (regions) {
+        free(regions);
+        regions = NULL;
+    }
 
     // No match found
     log_error("No match found for the given signature");

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -257,7 +257,6 @@ int perform_sig_scan(lua_State* L)
                         free(regions);
                         regions = NULL;
                     }
-
                     lua_pushnumber(L, result);
                     return 1;
                 }

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -249,7 +249,7 @@ int perform_sig_scan(lua_State* L)
                     // go out of memory (due to commit 2b4417f offsetting memory reads)
                     // So this result might be negative if the main module happens to be after
                     // the found signature. This should be corrected by readAddress.
-                    intptr_t result = (mem_iter->cursor + j + offset) - process.base_address;
+                    intptr_t result = (mem_iter->last_cursor + j + offset) - process.base_address;
 
                     lua_pushnumber(L, result);
                     ret = 1;

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -253,6 +253,10 @@ int perform_sig_scan(lua_State* L)
                         free(pattern);
                         pattern = NULL;
                     }
+                    if (regions) {
+                        free(regions);
+                        regions = NULL;
+                    }
 
                     lua_pushnumber(L, result);
                     return 1;

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -188,7 +188,6 @@ int perform_sig_scan(lua_State* L)
     int ret = 1;
     MemoryIterator* mem_iter = NULL;
     uint16_t* pattern = NULL;
-    uint8_t* buffer = NULL;
     ProcessMap* regions = NULL;
     if (lua_gettop(L) != 2) {
         log_error("Invalid number of arguments: expected 2 (signature, offset)");
@@ -238,12 +237,11 @@ int perform_sig_scan(lua_State* L)
         ProcessMap region = regions[i];
         mem_iter = mem_iterator_new(p_pid, region.start, region.end, pattern_length);
         uint8_t err = 0;
-        size_t buffer_length;
-        while (mem_next(&buffer, &buffer_length, mem_iter, &err)) {
+        while (mem_next(mem_iter, &err)) {
             // Now buffer contains the read memory chunk
-            assert(buffer_length >= pattern_length);
-            for (size_t j = 0; j <= buffer_length - pattern_length; ++j) {
-                if (match_pattern(buffer + j, pattern, pattern_length)) {
+            assert(mem_iter->buffer_size >= pattern_length);
+            for (size_t j = 0; j <= mem_iter->buffer_size - pattern_length; ++j) {
+                if (match_pattern(mem_iter->buffer + j, pattern, pattern_length)) {
                     // The resulting address is the start of the region
                     // plus the index of the first byte that matches
                     // plus the user-set offset, minus the process's base_address
@@ -278,12 +276,9 @@ int perform_sig_scan(lua_State* L)
     lua_pushnil(L);
     ret = 1;
 cleanup:
-    free(buffer);
-    buffer = NULL;
     free(pattern);
     pattern = NULL;
-    free(mem_iter);
-    mem_iter = NULL;
+    mem_iterator_destroy(mem_iter);
     free(regions);
     regions = NULL;
     return ret;

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -5,7 +5,6 @@
 #include "../memory_iter/memory_iterator.h"
 #include "../utils.h"
 
-#include <assert.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <lua.h>
@@ -166,14 +165,12 @@ int perform_sig_scan(lua_State* L)
     if (lua_gettop(L) != 2) {
         log_error("Invalid number of arguments: expected 2 (signature, offset)");
         lua_pushnil(L);
-        ret = 1;
         goto cleanup;
     }
 
     if (!lua_isstring(L, 1) || !lua_isnumber(L, 2)) {
         log_error("Invalid argument types: expected (string, number)");
         lua_pushnil(L);
-        ret = 1;
         goto cleanup;
     }
 
@@ -185,7 +182,6 @@ int perform_sig_scan(lua_State* L)
     if (strlen(signature) == 0) {
         log_error("Signature string cannot be empty");
         lua_pushnil(L);
-        ret = 1;
         goto cleanup;
     }
 
@@ -194,7 +190,6 @@ int perform_sig_scan(lua_State* L)
     if (!pattern) {
         log_error("Failed to convert signature");
         lua_pushnil(L);
-        ret = 1;
         goto cleanup;
     }
 
@@ -203,23 +198,29 @@ int perform_sig_scan(lua_State* L)
     if (!regions) {
         log_error("Failed to get memory regions");
         lua_pushnil(L);
-        ret = 1;
         goto cleanup;
     }
 
     // Forward initialization of the memory iterator.
     mem_iter = mem_iterator_new(p_pid, 0, 0, pattern_length);
 
+    // By construction, the memory iterator buffer size is MEMORY_WINDOW_SIZE
+    if (pattern_length >= mem_iter->buffer_size) {
+        LOG_ERR("Memory signature provided is too large.");
+        lua_pushnil(L);
+        goto cleanup;
+    }
+
     for (size_t i = 0; i < regions_count; i++) {
         ProcessMap region = regions[i];
         if (!mem_iterator_recycle(&mem_iter, p_pid, region.start, region.end, pattern_length)) {
             LOG_ERR("Unable to recycle memory iterator, exiting the sig_scan loop");
+            lua_pushnil(L);
             goto cleanup;
         }
         uint8_t err = 0;
         while (mem_next(mem_iter, &err)) {
             // Now buffer contains the read memory chunk
-            assert(mem_iter->buffer_size >= pattern_length);
             for (size_t j = 0; j <= mem_iter->buffer_size - pattern_length; ++j) {
                 if (match_pattern(mem_iter->buffer + j, pattern, pattern_length)) {
                     // The resulting address is the start of the region
@@ -232,7 +233,6 @@ int perform_sig_scan(lua_State* L)
                     intptr_t result = (mem_iter->last_cursor + j + offset) - process.base_address;
 
                     lua_pushnumber(L, result);
-                    ret = 1;
                     goto cleanup;
                 }
             }
@@ -244,22 +244,24 @@ int perform_sig_scan(lua_State* L)
         if (err) {
             log_error("There has been an error in sig_scan: error code %d", err);
             lua_pushnil(L);
-            ret = 1;
             goto cleanup;
         }
     }
 
     // No match found
     log_error("No match found for the given signature");
-    ret = 1;
+    lua_pushnil(L);
 cleanup:
     if (maps_cache_cycles == 0) {
+        // maps_clearCache takes care of freeing regions by itself.
+        // if we do a free(regions) we'll run into a double-free problem.
         maps_clearCache();
+    } else {
+        free(regions);
     }
+    regions = NULL;
     free(pattern);
     pattern = NULL;
     mem_iterator_destroy(&mem_iter);
-    free(regions);
-    regions = NULL;
     return ret;
 }

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -32,6 +32,7 @@ MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uint
     iter->end = end;
     iter->overlap = overlap;
     iter->cursor = start;
+    iter->last_cursor = start;
     return iter;
 }
 
@@ -57,7 +58,9 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
     }
     if (iterator->cursor + window_size > iterator->end) {
         // We're at the last iteration and the window size is too big
-        window_size = iterator->end - iterator->cursor;
+        // FIXME: [Penaz] [2026-04-02] I received a short memory read while testing, this
+        // ^ might not work
+        window_size = (size_t)(iterator->end - iterator->cursor);
         last_iter = true;
     }
     // Reallocate buffer for reading
@@ -74,6 +77,7 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
     struct iovec remote_iov = { (void*)iterator->cursor, window_size };
     ssize_t nread = process_vm_readv(iterator->pid, &local_iov, 1, &remote_iov, 1, 0);
     if (nread == (ssize_t)window_size) {
+        iterator->last_cursor = iterator->cursor;
         // If read is okay, move the cursor forward
         iterator->cursor += window_size;
         if (!last_iter) {
@@ -85,7 +89,8 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
         return 1;
     } else {
         if (nread < 0) {
-            LOG_WARNF("Memory read error, errno is %d (%s)", errno, strerror(errno));
+            LOG_DEBUGF("Memory read error, errno is %d (%s)", errno, strerror(errno));
+            LOG_DEBUGF("Cursor: %x, Start: %x, End: %x, Overlap: %x", iterator->cursor, iterator->start, iterator->end, iterator->overlap);
             *err = 3;
         } else {
             // Memory read error

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -136,3 +136,36 @@ bool mem_iterator_destroy(MemoryIterator** iterator)
     }
     return true;
 }
+
+/**
+ * Reinitialies an existing MemoryIterator to avoid useless reinstantiations.
+ *
+ * This works on quite a big assumption: that the buffer inside of the MemoryIterator
+ * is MEMORY_WINDOW_SIZE big at allocation time. This should be a given if MemoryIterator
+ * was created via mem_iterator_new().
+ *
+ * @param[inout] iter The reference to the Memory Iterator to recycle.
+ * @param[in] pid The process ID to tie the MemoryIterator to.
+ * @param[in] start The start address to start the scan from.
+ * @param[in] end The end address onto where to finish the scan.
+ * @param[in] overlap The amount of overlap between two successive iterations.
+ */
+bool mem_iterator_recycle(MemoryIterator** iter, pid_t pid, uintptr_t start, uintptr_t end, uintptr_t overlap)
+{
+    if (*iter == NULL) {
+        LOG_ERR("Cannot recycle NULL pointers.");
+        return false;
+    }
+    if ((*iter)->buffer == NULL) {
+        LOG_ERR("Cannot recycle a memory iterator with a NULL buffer");
+        return false;
+    }
+    (*iter)->pid = pid;
+    (*iter)->start = start;
+    (*iter)->end = end;
+    (*iter)->overlap = overlap;
+    (*iter)->cursor = start;
+    (*iter)->last_cursor = start;
+    (*iter)->buffer_size = MEMORY_WINDOW_SIZE;
+    return true;
+}

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -125,7 +125,7 @@ int mem_next(MemoryIterator* iterator, uint8_t* err)
     return 0;
 }
 
-bool memory_iterator_destroy(MemoryIterator* iterator)
+bool mem_iterator_destroy(MemoryIterator* iterator)
 {
     free(iterator->buffer);
     iterator->buffer = NULL;

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -47,6 +47,7 @@ MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uint
  */
 int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, uint8_t* err)
 {
+    assert(iterator != NULL);
     size_t window_size = MEMORY_WINDOW_SIZE;
     bool last_iter = false;
     assert(iterator->cursor >= iterator->start);

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-const size_t MEMORY_WINDOW_SIZE = 0x100000; /*!< The size of the memory chunks to be read*/
+const size_t MEMORY_WINDOW_SIZE = 0x10000; /*!< The size of the memory chunks to be read*/
 
 /**
  * Creates a new chunked Memory Iterator.

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -49,29 +49,34 @@ MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uint
 int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, uint8_t* err)
 {
     assert(iterator != NULL);
+    assert(iterator->cursor >= iterator->start);
     size_t window_size = MEMORY_WINDOW_SIZE;
     bool last_iter = false;
-    assert(iterator->cursor >= iterator->start);
     if (iterator->cursor >= iterator->end) {
         // We passed the end in the last iteration. Stop.
         return 0;
     }
     if (iterator->cursor + window_size > iterator->end) {
         // We're at the last iteration and the window size is too big
-        // FIXME: [Penaz] [2026-04-02] I received a short memory read while testing, this
-        // ^ might not work
         window_size = (size_t)(iterator->end - iterator->cursor);
         last_iter = true;
+        if (window_size == 0) {
+            // Nothing more to read
+            return 0;
+        }
     }
     // Reallocate buffer for reading
-    *buffer = (uint8_t*)realloc(*buffer, window_size);
-    if (*buffer == NULL) {
+    // PERF: Since we now accept short reads, we may not need to realloc every time
+    // ^ just alloc the biggest accepted read once. Maybe pointer should be in the iterator struct?
+    uint8_t* tmp = realloc(*buffer, window_size);
+    if (tmp == NULL) {
         // Cannot allocate buffer, stop immediately
         LOG_WARN("Unable to allocate memory read buffer");
         *err = 1;
         return 0;
     }
-    *buffer_size = window_size;
+    *buffer = tmp;
+    tmp = NULL;
     // Read memory
     struct iovec local_iov = { *buffer, window_size };
     struct iovec remote_iov = { (void*)iterator->cursor, window_size };
@@ -85,17 +90,43 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
             // Matches between chunks
             iterator->cursor -= iterator->overlap;
         }
+        *buffer_size = window_size;
         // There are more things to read
         return 1;
     } else {
         if (nread < 0) {
+            if (errno == EINTR) {
+                // TODO: [Penaz] [2026-04-02] Memory read interrupted by a transitory interruption.
+                // For now we'll still bail out. but ideally we should retry.
+                LOG_DEBUG("Read interrupted by EINTR");
+            }
             LOG_DEBUGF("Memory read error, errno is %d (%s)", errno, strerror(errno));
             LOG_DEBUGF("Cursor: %x, Start: %x, End: %x, Overlap: %x", iterator->cursor, iterator->start, iterator->end, iterator->overlap);
             *err = 3;
+        } else if (nread == 0) {
+            // No bytes read. We stop here
+            *buffer_size = 0;
+            return 0;
         } else {
-            // Memory read error
-            LOG_WARNF("Memory read error: nread=%zd, expected=%td", nread, window_size);
-            *err = 2;
+            // Short read
+            LOG_WARNF("Short memory read: nread=%zd, expected=%td", nread, window_size);
+            // Save the short read cursor
+            iterator->last_cursor = iterator->cursor;
+            // Advance by the number of bytes read
+            *buffer_size = (size_t)nread;
+            iterator->cursor += (size_t)nread;
+            if (!last_iter) {
+                // If we're not done, move it backwards a little to account for
+                // Matches between chunks. If the nread is shorter, we accept the lost loop
+                // and hope for next loop to come and save us
+                if (nread > iterator->overlap) {
+                    iterator->cursor -= iterator->overlap;
+                } else {
+                    // At least advance 1 byte
+                    iterator->cursor -= nread + 1;
+                }
+            }
+            return 1;
         }
     }
     // Nothing more to read or error has happened.

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -39,7 +39,7 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
     }
     // Reallocate buffer for reading
     *buffer = (uint8_t*)realloc(*buffer, window_size);
-    if (buffer == NULL) {
+    if (*buffer == NULL) {
         // Cannot allocate buffer, stop immediately
         LOG_WARN("Unable to allocate memory read buffer");
         *err = 1;

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -27,26 +27,30 @@ MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uint
     if (iter == NULL) {
         return NULL;
     }
+    iter->buffer = (uint8_t*)malloc(MEMORY_WINDOW_SIZE);
+    if (iter->buffer == NULL) {
+        free(iter);
+        return NULL;
+    }
     iter->pid = pid;
     iter->start = start;
     iter->end = end;
     iter->overlap = overlap;
     iter->cursor = start;
     iter->last_cursor = start;
+    iter->buffer_size = MEMORY_WINDOW_SIZE;
     return iter;
 }
 
 /**
  * Reads the next chunk of memory.
  *
- * @param[out] buffer The buffer to copy memory into.
- * @param[out] buffer_size The size of the buffer that is allocated by the iterator.
  * @param[in] iterator The pointer to the MemoryIterator used.
  * @param[out] err The error code returned to the calling function.
  *
  * @returns 1 if there has been a memory read, 0 otherwise.
  */
-int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, uint8_t* err)
+int mem_next(MemoryIterator* iterator, uint8_t* err)
 {
     assert(iterator != NULL);
     assert(iterator->cursor >= iterator->start);
@@ -65,20 +69,8 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
             return 0;
         }
     }
-    // Reallocate buffer for reading
-    // PERF: Since we now accept short reads, we may not need to realloc every time
-    // ^ just alloc the biggest accepted read once. Maybe pointer should be in the iterator struct?
-    uint8_t* tmp = realloc(*buffer, window_size);
-    if (tmp == NULL) {
-        // Cannot allocate buffer, stop immediately
-        LOG_WARN("Unable to allocate memory read buffer");
-        *err = 1;
-        return 0;
-    }
-    *buffer = tmp;
-    tmp = NULL;
     // Read memory
-    struct iovec local_iov = { *buffer, window_size };
+    struct iovec local_iov = { iterator->buffer, window_size };
     struct iovec remote_iov = { (void*)iterator->cursor, window_size };
     ssize_t nread = process_vm_readv(iterator->pid, &local_iov, 1, &remote_iov, 1, 0);
     if (nread == (ssize_t)window_size) {
@@ -90,7 +82,7 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
             // Matches between chunks
             iterator->cursor -= iterator->overlap;
         }
-        *buffer_size = window_size;
+        iterator->buffer_size = window_size;
         // There are more things to read
         return 1;
     } else {
@@ -105,7 +97,7 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
             *err = 3;
         } else if (nread == 0) {
             // No bytes read. We stop here
-            *buffer_size = 0;
+            iterator->buffer_size = 0;
             return 0;
         } else {
             // Short read
@@ -113,7 +105,7 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
             // Save the short read cursor
             iterator->last_cursor = iterator->cursor;
             // Advance by the number of bytes read
-            *buffer_size = (size_t)nread;
+            iterator->buffer_size = (size_t)nread;
             iterator->cursor += (size_t)nread;
             if (!last_iter) {
                 // If we're not done, move it backwards a little to account for
@@ -131,4 +123,12 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
     }
     // Nothing more to read or error has happened.
     return 0;
+}
+
+bool memory_iterator_destroy(MemoryIterator* iterator)
+{
+    free(iterator->buffer);
+    iterator->buffer = NULL;
+    free(iterator);
+    return true;
 }

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -2,12 +2,14 @@
 #include "src/lasr/utils.h"
 #include "src/logging.h"
 #include <assert.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
-const ptrdiff_t MEMORY_WINDOW_SIZE = 0x100000; /*!< The size of the memory chunks to be read*/
+const size_t MEMORY_WINDOW_SIZE = 0x100000; /*!< The size of the memory chunks to be read*/
 
 /**
  * Creates a new chunked Memory Iterator.
@@ -45,7 +47,7 @@ MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uint
  */
 int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, uint8_t* err)
 {
-    ptrdiff_t window_size = MEMORY_WINDOW_SIZE;
+    size_t window_size = MEMORY_WINDOW_SIZE;
     bool last_iter = false;
     assert(iterator->cursor >= iterator->start);
     if (iterator->cursor >= iterator->end) {
@@ -81,9 +83,14 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
         // There are more things to read
         return 1;
     } else {
-        // Memory read error
-        LOG_WARN("Memory read error, possible short read");
-        *err = 2;
+        if (nread < 0) {
+            LOG_WARNF("Memory read error, errno is %d (%s)", errno, strerror(errno));
+            *err = 3;
+        } else {
+            // Memory read error
+            LOG_WARNF("Memory read error: nread=%zd, expected=%td", nread, window_size);
+            *err = 2;
+        }
     }
     // Nothing more to read or error has happened.
     return 0;

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -27,11 +27,12 @@ MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uint
     if (iter == NULL) {
         return NULL;
     }
-    iter->buffer = (uint8_t*)malloc(MEMORY_WINDOW_SIZE);
-    if (iter->buffer == NULL) {
+    uint8_t* tmp = (uint8_t*)malloc(MEMORY_WINDOW_SIZE);
+    if (tmp == NULL) {
         free(iter);
         return NULL;
     }
+    iter->buffer = tmp;
     iter->pid = pid;
     iter->start = start;
     iter->end = end;
@@ -89,7 +90,7 @@ int mem_next(MemoryIterator* iterator, uint8_t* err)
         if (nread < 0) {
             if (errno == EINTR) {
                 // TODO: [Penaz] [2026-04-02] Memory read interrupted by a transitory interruption.
-                // For now we'll still bail out. but ideally we should retry.
+                // ^ For now we'll still bail out. but ideally we should retry.
                 LOG_DEBUG("Read interrupted by EINTR");
             }
             LOG_DEBUGF("Memory read error, errno is %d (%s)", errno, strerror(errno));
@@ -109,13 +110,13 @@ int mem_next(MemoryIterator* iterator, uint8_t* err)
             iterator->cursor += (size_t)nread;
             if (!last_iter) {
                 // If we're not done, move it backwards a little to account for
-                // Matches between chunks. If the nread is shorter, we accept the lost loop
-                // and hope for next loop to come and save us
+                // Matches between chunks.
                 if (nread > iterator->overlap) {
+                    // If the short read is longer than the overlap, we try to continue
                     iterator->cursor -= iterator->overlap;
                 } else {
-                    // At least advance 1 byte
-                    iterator->cursor -= nread + 1;
+                    // If it is shorter, we bail and hope for the next loop
+                    return 0;
                 }
             }
             return 1;
@@ -125,10 +126,13 @@ int mem_next(MemoryIterator* iterator, uint8_t* err)
     return 0;
 }
 
-bool mem_iterator_destroy(MemoryIterator* iterator)
+bool mem_iterator_destroy(MemoryIterator** iterator)
 {
-    free(iterator->buffer);
-    iterator->buffer = NULL;
-    free(iterator);
+    if (*iterator != NULL) {
+        free((*iterator)->buffer);
+        (*iterator)->buffer = NULL;
+        free(*iterator);
+        *iterator = NULL;
+    }
     return true;
 }

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -1,0 +1,70 @@
+#include "memory_iterator.h"
+#include "src/lasr/utils.h"
+#include "src/logging.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+const ptrdiff_t MEMORY_WINDOW_SIZE = 0x100000;
+
+MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uintptr_t overlap)
+{
+    MemoryIterator* iter = malloc(sizeof(MemoryIterator));
+    if (iter == NULL) {
+        return NULL;
+    }
+    iter->pid = pid;
+    iter->start = start;
+    iter->end = end;
+    iter->overlap = overlap;
+    iter->cursor = start;
+    return iter;
+}
+
+int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, uint8_t* err)
+{
+    ptrdiff_t window_size = MEMORY_WINDOW_SIZE;
+    bool last_iter = false;
+    assert(iterator->cursor >= iterator->start);
+    if (iterator->cursor >= iterator->end) {
+        // We passed the end in the last iteration. Stop.
+        return 0;
+    }
+    if (iterator->cursor + window_size > iterator->end) {
+        // We're at the last iteration and the window size is too big
+        window_size = iterator->end - iterator->cursor;
+        last_iter = true;
+    }
+    // Reallocate buffer for reading
+    *buffer = (uint8_t*)realloc(*buffer, window_size);
+    if (buffer == NULL) {
+        // Cannot allocate buffer, stop immediately
+        LOG_WARN("Unable to allocate memory read buffer");
+        *err = 1;
+        return 0;
+    }
+    *buffer_size = window_size;
+    // Read memory
+    struct iovec local_iov = { *buffer, window_size };
+    struct iovec remote_iov = { (void*)iterator->cursor, window_size };
+    ssize_t nread = process_vm_readv(iterator->pid, &local_iov, 1, &remote_iov, 1, 0);
+    if (nread == (ssize_t)window_size) {
+        // If read is okay, move the cursor forward
+        iterator->cursor += window_size;
+        if (!last_iter) {
+            // If we're not done, move it backwards a little to account for
+            // Matches between chunks
+            iterator->cursor -= iterator->overlap;
+        }
+        // There are more things to read
+        return 1;
+    } else {
+        // Memory read error
+        // TODO: [Penaz] [2026-04-01] Change this to an enum
+        *err = 2;
+    }
+    // Nothing more to read or error has happened.
+    return 0;
+}

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -54,6 +54,7 @@ MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uint
 int mem_next(MemoryIterator* iterator, uint8_t* err)
 {
     assert(iterator != NULL);
+    assert(iterator->cursor != 0);
     assert(iterator->cursor >= iterator->start);
     size_t window_size = MEMORY_WINDOW_SIZE;
     bool last_iter = false;

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -62,7 +62,7 @@ int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, ui
         return 1;
     } else {
         // Memory read error
-        // TODO: [Penaz] [2026-04-01] Change this to an enum
+        LOG_WARN("Memory read error, possible short read");
         *err = 2;
     }
     // Nothing more to read or error has happened.

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -7,8 +7,18 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-const ptrdiff_t MEMORY_WINDOW_SIZE = 0x100000;
+const ptrdiff_t MEMORY_WINDOW_SIZE = 0x100000; /*!< The size of the memory chunks to be read*/
 
+/**
+ * Creates a new chunked Memory Iterator.
+ *
+ * @param[in] pid The process id to scan for.
+ * @param[in] start The start address to start the scan from.
+ * @param[in] end The end address onto where to finish the scan.
+ * @param[in] overlap The amount of overlap between two successive iterations.
+ *
+ * @returns A pointer to a new memory iterator.
+ */
 MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uintptr_t overlap)
 {
     MemoryIterator* iter = malloc(sizeof(MemoryIterator));
@@ -23,6 +33,16 @@ MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uint
     return iter;
 }
 
+/**
+ * Reads the next chunk of memory.
+ *
+ * @param[out] buffer The buffer to copy memory into.
+ * @param[out] buffer_size The size of the buffer that is allocated by the iterator.
+ * @param[in] iterator The pointer to the MemoryIterator used.
+ * @param[out] err The error code returned to the calling function.
+ *
+ * @returns 1 if there has been a memory read, 0 otherwise.
+ */
 int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, uint8_t* err)
 {
     ptrdiff_t window_size = MEMORY_WINDOW_SIZE;

--- a/src/lasr/memory_iter/memory_iterator.c
+++ b/src/lasr/memory_iter/memory_iterator.c
@@ -1,7 +1,6 @@
 #include "memory_iterator.h"
 #include "src/lasr/utils.h"
 #include "src/logging.h"
-#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -53,9 +52,21 @@ MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uint
  */
 int mem_next(MemoryIterator* iterator, uint8_t* err)
 {
-    assert(iterator != NULL);
-    assert(iterator->cursor != 0);
-    assert(iterator->cursor >= iterator->start);
+    if (iterator == NULL) {
+        LOG_ERR("Programming Error: Trying to use a NULL iterator");
+        return 0;
+    }
+    if (iterator->cursor == 0) {
+        LOG_ERR("Programming Error: the memory iterator cursor is pointing at address zero.");
+        return 0;
+    }
+    if (iterator->cursor < iterator->start) {
+        LOG_ERRF(
+            "Programming Error: Iterator cursor address has a lower value (%x) than its starting memory address (%x)",
+            iterator->cursor,
+            iterator->start);
+        return 0;
+    }
     size_t window_size = MEMORY_WINDOW_SIZE;
     bool last_iter = false;
     if (iterator->cursor >= iterator->end) {

--- a/src/lasr/memory_iter/memory_iterator.h
+++ b/src/lasr/memory_iter/memory_iterator.h
@@ -1,0 +1,19 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+/**
+ * Defines a Memory Iterator, keeping track
+ * of a cursor in memory and used with other functions for
+ * chunked reading.
+ */
+typedef struct _MemoryIterator {
+    pid_t pid; /*!< ID of the process to be iterated over */
+    uintptr_t start; /*!< Keeps the start address of the region to be read */
+    uintptr_t end; /*!< Keeps the end address of the region to be read */
+    uintptr_t cursor; /*!< The pointer to the beginning of the memory region to be read*/
+    ptrdiff_t overlap; /*!< The overlap between two memory chunks to maintain */
+} MemoryIterator;
+
+MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uintptr_t overlap);
+int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, uint8_t* err);

--- a/src/lasr/memory_iter/memory_iterator.h
+++ b/src/lasr/memory_iter/memory_iterator.h
@@ -22,3 +22,4 @@ typedef struct _MemoryIterator {
 MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uintptr_t overlap);
 int mem_next(MemoryIterator* iterator, uint8_t* err);
 bool mem_iterator_destroy(MemoryIterator** iterator);
+bool mem_iterator_recycle(MemoryIterator** iterator, pid_t pid, uintptr_t start, uintptr_t end, uintptr_t overlap);

--- a/src/lasr/memory_iter/memory_iterator.h
+++ b/src/lasr/memory_iter/memory_iterator.h
@@ -11,7 +11,8 @@ typedef struct _MemoryIterator {
     pid_t pid; /*!< ID of the process to be iterated over */
     uintptr_t start; /*!< Keeps the start address of the region to be read */
     uintptr_t end; /*!< Keeps the end address of the region to be read */
-    uintptr_t cursor; /*!< The pointer to the beginning of the memory region to be read*/
+    uintptr_t last_cursor; /*!< The pointer to the beginning of the memory chunk to be scanned */
+    uintptr_t cursor; /*!< The pointer to the beginning of the next memory chunk to be read */
     ptrdiff_t overlap; /*!< The overlap between two memory chunks to maintain */
 } MemoryIterator;
 

--- a/src/lasr/memory_iter/memory_iterator.h
+++ b/src/lasr/memory_iter/memory_iterator.h
@@ -21,4 +21,4 @@ typedef struct _MemoryIterator {
 
 MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uintptr_t overlap);
 int mem_next(MemoryIterator* iterator, uint8_t* err);
-bool mem_iterator_destroy(MemoryIterator* iterator);
+bool mem_iterator_destroy(MemoryIterator** iterator);

--- a/src/lasr/memory_iter/memory_iterator.h
+++ b/src/lasr/memory_iter/memory_iterator.h
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/types.h>
@@ -14,7 +15,10 @@ typedef struct _MemoryIterator {
     uintptr_t last_cursor; /*!< The pointer to the beginning of the memory chunk to be scanned */
     uintptr_t cursor; /*!< The pointer to the beginning of the next memory chunk to be read */
     ptrdiff_t overlap; /*!< The overlap between two memory chunks to maintain */
+    uint8_t* buffer;
+    size_t buffer_size;
 } MemoryIterator;
 
 MemoryIterator* mem_iterator_new(pid_t pid, uintptr_t start, uintptr_t end, uintptr_t overlap);
-int mem_next(uint8_t** buffer, size_t* buffer_size, MemoryIterator* iterator, uint8_t* err);
+int mem_next(MemoryIterator* iterator, uint8_t* err);
+bool mem_iterator_destroy(MemoryIterator* iterator);


### PR DESCRIPTION
**Rationale:** Reduces memory usage and lowers the size of each copy. Abstracts the "iterate through memory" process, allowing for new implementations of `sig_scan`.

Instead of copying the entire memory map in LibreSplit, we decide to read chunks of memory to reduce RAM usage.

This is done via an "iterator-like" interface that tries to hide the complexities and might be used in other places in the future (or by plugins, see #340)

Requires #348 first, to avoid code duplication.

The current version bails out on reads that are shorter than its "window overlap". I'm sure there is a better way to go at this, but I think this is my limit.