### PR TITLE
RPM Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,6 @@ on:
             source_sha:
                 required: true
                 type: string
-            packaging_sha:
-                required: true
-                type: string
 
 permissions: {}
 
@@ -181,7 +178,6 @@ jobs:
                     - architecture: aarch64
                       runner: ubuntu-24.04-arm
         env:
-            PACKAGING_SHA: ${{ inputs.packaging_sha }}
             RPM_RELEASE: ${{ inputs.rpm_release }}
             SOURCE_SHA: ${{ inputs.source_sha }}
             VERSION: ${{ inputs.version }}
@@ -194,22 +190,13 @@ jobs:
                   git-core
                   rpm-build
 
-            - name: Check out LibreSplit source
+            - name: Check out LibreSplit
               uses: actions/checkout@v7
               with:
-                  fetch-depth: 1
+                  fetch-depth: 0
                   path: source
                   persist-credentials: false
-                  ref: ${{ inputs.source_sha }}
-
-            - name: Check out RPM packaging
-              uses: actions/checkout@v7
-              with:
-                  fetch-depth: 1
-                  path: packaging-policy
-                  persist-credentials: false
-                  ref: ${{ inputs.packaging_sha }}
-                  repository: LibreSplit/rpm.libresplit.org
+                  ref: main
 
             - name: Prepare RPM sources
               run: |
@@ -230,11 +217,10 @@ jobs:
                     --output="${rpm_topdir}/SOURCES/libresplit-${VERSION}.tar.gz" \
                     "${SOURCE_SHA}"
 
-                  cp packaging-policy/packaging/libresplit.spec "${rpm_topdir}/SPECS/libresplit.spec"
+                  cp source/assets/rpm/libresplit.spec "${rpm_topdir}/SPECS/libresplit.spec"
                   cp \
-                    packaging-policy/packaging/libresplit.repo \
-                    packaging-policy/packaging/RPM-GPG-KEY-libresplit \
-                    packaging-policy/packaging/org.libresplit.LibreSplit.metainfo.xml \
+                    source/assets/rpm/libresplit.repo \
+                    source/assets/rpm/org.libresplit.LibreSplit.metainfo.xml \
                     "${rpm_topdir}/SOURCES/"
 
             - name: Install RPM build dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,46 @@
-on: [push, pull_request]
+name: Build
+
+on:
+    push:
+    pull_request:
+    workflow_call:
+        inputs:
+            version:
+                required: true
+                type: string
+            rpm_release:
+                required: true
+                type: string
+            source_sha:
+                required: true
+                type: string
+            packaging_sha:
+                required: true
+                type: string
+
+permissions: {}
 
 jobs:
     build:
         runs-on: ubuntu-24.04
         name: Build
+        permissions:
+            contents: read
         steps:
             - name: "Checkout"
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  ref: ${{ inputs.source_sha }}
+
+            - name: "Set release version"
+              if: inputs.version != ''
+              env:
+                  VERSION: ${{ inputs.version }}
+              run: |
+                  # Replace pre-release version with semantic versioning
+                  sed -i "s/version: 'pre-release'/version: '${VERSION}'/" meson.build
+                  grep -Fq "version: '${VERSION}'" meson.build
 
             - name: "Install and cache C dependencies"
               uses: awalsh128/cache-apt-pkgs-action@latest
@@ -35,6 +67,24 @@ jobs:
               shell: bash
               run: echo "git_short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
+            - name: Set artifact names
+              id: artifacts
+              env:
+                  STABLE_RELEASE: ${{ inputs.version != '' }}
+                  VERSION: ${{ inputs.version }}
+              run: |
+                  if [[ "${STABLE_RELEASE}" == "true" ]]; then
+                    echo "standalone=LibreSplit-${VERSION}-standalone-x86_64" >> "${GITHUB_OUTPUT}"
+                    echo "appimage=LibreSplit-${VERSION}-x86_64.AppImage" >> "${GITHUB_OUTPUT}"
+                    echo "zsync=LibreSplit-${VERSION}-x86_64.AppImage.zsync" >> "${GITHUB_OUTPUT}"
+                    echo "update_channel=latest" >> "${GITHUB_OUTPUT}"
+                  else
+                    echo "standalone=LibreSplit-${build_number}-${git_short_sha}-standalone" >> "${GITHUB_OUTPUT}"
+                    echo "appimage=LibreSplit-${build_number}-${git_short_sha}-nightly-x86_64.AppImage" >> "${GITHUB_OUTPUT}"
+                    echo "zsync=LibreSplit-nightly-x86_64.AppImage.zsync" >> "${GITHUB_OUTPUT}"
+                    echo "update_channel=nightly" >> "${GITHUB_OUTPUT}"
+                  fi
+
             - name: "Bundle extra files"
               run: |
                   rm -rf release
@@ -44,16 +94,21 @@ jobs:
                   # Include extra non-installed files
                   cp -r assets release/
 
+            - name: "Create standalone archive"
+              env:
+                  STANDALONE_NAME: ${{ steps.artifacts.outputs.standalone }}
+              run: cd release && zip -qr "../${STANDALONE_NAME}.zip" .
+
             - name: "Upload artifacts"
               uses: actions/upload-artifact@v4
               with:
-                  name: LibreSplit-${{ env.build_number }}-${{ env.git_short_sha }}-standalone
-                  path: release/
+                  name: ${{ steps.artifacts.outputs.standalone }}
+                  path: ${{ steps.artifacts.outputs.standalone }}.zip
 
             - name: "Install AppImage dependencies"
               run: |
                   sudo apt -y update
-                  sudo apt -y install desktop-file-utils libluajit-5.1-dev
+                  sudo apt -y install desktop-file-utils libluajit-5.1-dev zsync
 
             - name: "Prepare AppDir from release artifact"
               run: |
@@ -86,34 +141,147 @@ jobs:
                   chmod +x linuxdeploy-plugin-appimage-x86_64.AppImage
 
             - name: "Create AppImage"
+              env:
+                  APPIMAGE_NAME: ${{ steps.artifacts.outputs.appimage }}
+                  UPDATE_CHANNEL: ${{ steps.artifacts.outputs.update_channel }}
+                  ZSYNC_NAME: ${{ steps.artifacts.outputs.zsync }}
               run: |
-                  LDAI_UPDATE_INFORMATION="gh-releases-zsync|${{ github.repository_owner }}|LibreSplit|nightly|LibreSplit-*x86_64.AppImage.zsync" \
+                  LDAI_OUTPUT="${APPIMAGE_NAME}" \
+                  LDAI_UPDATE_INFORMATION="gh-releases-zsync|${{ github.repository_owner }}|LibreSplit|${UPDATE_CHANNEL}|LibreSplit-*x86_64.AppImage.zsync" \
                   ./linuxdeploy-x86_64.AppImage --appdir AppDir --desktop-file AppDir/libresplit.desktop --icon-file AppDir/libresplit.png --output appimage
-                  mv LibreSplit-x86_64.AppImage LibreSplit-${{ env.build_number }}-${{ env.git_short_sha }}-nightly-x86_64.AppImage
-                  mv LibreSplit-x86_64.AppImage.zsync LibreSplit-nightly-x86_64.AppImage.zsync
+                  if [[ "${APPIMAGE_NAME}.zsync" != "${ZSYNC_NAME}" ]]; then
+                    mv "${APPIMAGE_NAME}.zsync" "${ZSYNC_NAME}"
+                  fi
 
             - name: "Upload AppImage"
               uses: actions/upload-artifact@v4
               with:
-                  path: LibreSplit-${{ env.build_number }}-${{ env.git_short_sha }}-nightly-x86_64.AppImage
-                  name: LibreSplit-${{ env.build_number }}-${{ env.git_short_sha }}-nightly-x86_64.AppImage
+                  path: ${{ steps.artifacts.outputs.appimage }}
+                  name: ${{ steps.artifacts.outputs.appimage }}
 
             - name: "Upload AppImage zsync"
               uses: actions/upload-artifact@v4
               with:
-                  path: LibreSplit-nightly-x86_64.AppImage.zsync
-                  name: LibreSplit-nightly-x86_64.AppImage.zsync
+                  path: ${{ steps.artifacts.outputs.zsync }}
+                  name: ${{ steps.artifacts.outputs.zsync }}
+
+    rpm:
+        if: inputs.version != ''
+        name: Build RPM (${{ matrix.architecture }})
+        runs-on: ${{ matrix.runner }}
+        container: registry.fedoraproject.org/fedora:44
+        permissions:
+            contents: write
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - architecture: x86_64
+                      runner: ubuntu-24.04
+                    - architecture: aarch64
+                      runner: ubuntu-24.04-arm
+        env:
+            PACKAGING_SHA: ${{ inputs.packaging_sha }}
+            RPM_RELEASE: ${{ inputs.rpm_release }}
+            SOURCE_SHA: ${{ inputs.source_sha }}
+            VERSION: ${{ inputs.version }}
+        steps:
+            - name: Check out LibreSplit source
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 1
+                  path: source
+                  persist-credentials: false
+                  ref: ${{ inputs.source_sha }}
+
+            - name: Check out RPM packaging
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 1
+                  path: packaging-policy
+                  persist-credentials: false
+                  ref: ${{ inputs.packaging_sha }}
+                  repository: LibreSplit/rpm.libresplit.org
+
+            - name: Install Fedora tooling
+              run: >-
+                  dnf install --assumeyes
+                  dnf5-plugins
+                  gh
+                  git-core
+                  rpm-build
+
+            - name: Prepare RPM sources
+              run: |
+                  set -euo pipefail
+
+                  rpm_topdir="${RUNNER_TEMP}/rpmbuild"
+                  install -d \
+                    "${rpm_topdir}/BUILD" \
+                    "${rpm_topdir}/BUILDROOT" \
+                    "${rpm_topdir}/RPMS" \
+                    "${rpm_topdir}/SOURCES" \
+                    "${rpm_topdir}/SPECS" \
+                    "${rpm_topdir}/SRPMS"
+
+                  git -C source archive \
+                    --format=tar.gz \
+                    --prefix="libresplit-${VERSION}/" \
+                    --output="${rpm_topdir}/SOURCES/libresplit-${VERSION}.tar.gz" \
+                    "${SOURCE_SHA}"
+
+                  cp packaging-policy/packaging/libresplit.spec "${rpm_topdir}/SPECS/libresplit.spec"
+                  cp \
+                    packaging-policy/packaging/libresplit.repo \
+                    packaging-policy/packaging/RPM-GPG-KEY-libresplit \
+                    packaging-policy/packaging/org.libresplit.LibreSplit.metainfo.xml \
+                    "${rpm_topdir}/SOURCES/"
+
+            - name: Install RPM build dependencies
+              run: |
+                  rpm_topdir="${RUNNER_TEMP}/rpmbuild"
+                  dnf --assumeyes builddep \
+                    -D "libresplit_version ${VERSION}" \
+                    -D "libresplit_release ${RPM_RELEASE}" \
+                    --spec "${rpm_topdir}/SPECS/libresplit.spec"
+
+            - name: Build RPM
+              run: |
+                  rpm_topdir="${RUNNER_TEMP}/rpmbuild"
+                  rpmbuild -bb \
+                    --define "_topdir ${rpm_topdir}" \
+                    --define "libresplit_version ${VERSION}" \
+                    --define "libresplit_release ${RPM_RELEASE}" \
+                    "${rpm_topdir}/SPECS/libresplit.spec"
+
+            - name: Upload unsigned RPM
+              env:
+                  ARCHITECTURE: ${{ matrix.architecture }}
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  rpm_topdir="${RUNNER_TEMP}/rpmbuild"
+                  built_rpm="${rpm_topdir}/RPMS/${ARCHITECTURE}/libresplit-${VERSION}-${RPM_RELEASE}.${ARCHITECTURE}.rpm"
+                  unsigned_rpm="${RUNNER_TEMP}/libresplit-${VERSION}-${RPM_RELEASE}.${ARCHITECTURE}.unsigned.rpm"
+
+                  cp "${built_rpm}" "${unsigned_rpm}"
+                  gh release upload \
+                    "v${VERSION}" \
+                    "${unsigned_rpm}" \
+                    --clobber \
+                    --repo "${GITHUB_REPOSITORY}"
 
     create-nightly-release:
         name: "Upload nightly release"
         needs: [build]
         runs-on: ubuntu-latest
         permissions:
-            contents: write 
+            contents: write
         concurrency:
             group: create-release
             cancel-in-progress: false
         if: |
+            github.event_name == 'push' &&
+            inputs.version == '' &&
             github.ref == 'refs/heads/main' &&
             github.repository == 'LibreSplit/LibreSplit'
         steps:
@@ -154,7 +322,7 @@ jobs:
                       cp $dir/*.AppImage.zsync artifacts-master/
                     elif [[ $dir == *-standalone ]]; then
                       echo "Processing $dir (Standalone x86_64)"
-                      (cd $dir && zip -r ../artifacts-master/$dir.zip *)
+                      cp "$dir/$dir.zip" artifacts-master/
                     fi
                   done
                   echo "=== artifacts-master ==="

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,14 @@ jobs:
             SOURCE_SHA: ${{ inputs.source_sha }}
             VERSION: ${{ inputs.version }}
         steps:
+            - name: Install Fedora tooling
+              run: >-
+                  dnf install --assumeyes
+                  dnf5-plugins
+                  gh
+                  git-core
+                  rpm-build
+
             - name: Check out LibreSplit source
               uses: actions/checkout@v7
               with:
@@ -202,14 +210,6 @@ jobs:
                   persist-credentials: false
                   ref: ${{ inputs.packaging_sha }}
                   repository: LibreSplit/rpm.libresplit.org
-
-            - name: Install Fedora tooling
-              run: >-
-                  dnf install --assumeyes
-                  dnf5-plugins
-                  gh
-                  git-core
-                  rpm-build
 
             - name: Prepare RPM sources
               run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,6 +82,8 @@ jobs:
               run: |
                   set -euo pipefail
 
+                  git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
                   rpm_topdir="${RUNNER_TEMP}/rpmbuild"
                   install -d \
                     "${rpm_topdir}/BUILD" \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -69,15 +69,6 @@ jobs:
                   fetch-depth: 1
                   persist-credentials: false
 
-            - name: Checkout RPM packaging
-              uses: actions/checkout@v7
-              with:
-                  fetch-depth: 1
-                  path: packaging-policy
-                  persist-credentials: false
-                  ref: main
-                  repository: LibreSplit/rpm.libresplit.org
-
             - name: Prepare RPM sources
               run: |
                   set -euo pipefail
@@ -99,11 +90,10 @@ jobs:
                     --output="${rpm_topdir}/SOURCES/libresplit-${VERSION}.tar.gz" \
                     HEAD
 
-                  cp packaging-policy/packaging/libresplit.spec "${rpm_topdir}/SPECS/libresplit.spec"
+                  cp assets/rpm/libresplit.spec "${rpm_topdir}/SPECS/libresplit.spec"
                   cp \
-                    packaging-policy/packaging/libresplit.repo \
-                    packaging-policy/packaging/RPM-GPG-KEY-libresplit \
-                    packaging-policy/packaging/org.libresplit.LibreSplit.metainfo.xml \
+                    assets/rpm/libresplit.repo \
+                    assets/rpm/org.libresplit.LibreSplit.metainfo.xml \
                     "${rpm_topdir}/SOURCES/"
 
             - name: Install RPM build dependencies

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,3 +46,77 @@ jobs:
 
             - name: Run linter tests
               run: meson test -C build --suite lint -v
+
+    build-check:
+        needs: linter-check
+        runs-on: ubuntu-24.04
+        container: registry.fedoraproject.org/fedora:44
+        env:
+            RPM_RELEASE: "1"
+            VERSION: "0.0.0"
+
+        steps:
+            - name: Install Fedora tooling
+              run: >-
+                  dnf install --assumeyes
+                  dnf5-plugins
+                  git-core
+                  rpm-build
+
+            - name: Checkout repository
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 1
+                  persist-credentials: false
+
+            - name: Checkout RPM packaging
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 1
+                  path: packaging-policy
+                  persist-credentials: false
+                  ref: main
+                  repository: LibreSplit/rpm.libresplit.org
+
+            - name: Prepare RPM sources
+              run: |
+                  set -euo pipefail
+
+                  rpm_topdir="${RUNNER_TEMP}/rpmbuild"
+                  install -d \
+                    "${rpm_topdir}/BUILD" \
+                    "${rpm_topdir}/BUILDROOT" \
+                    "${rpm_topdir}/RPMS" \
+                    "${rpm_topdir}/SOURCES" \
+                    "${rpm_topdir}/SPECS" \
+                    "${rpm_topdir}/SRPMS"
+
+                  git archive \
+                    --format=tar.gz \
+                    --prefix="libresplit-${VERSION}/" \
+                    --output="${rpm_topdir}/SOURCES/libresplit-${VERSION}.tar.gz" \
+                    HEAD
+
+                  cp packaging-policy/packaging/libresplit.spec "${rpm_topdir}/SPECS/libresplit.spec"
+                  cp \
+                    packaging-policy/packaging/libresplit.repo \
+                    packaging-policy/packaging/RPM-GPG-KEY-libresplit \
+                    packaging-policy/packaging/org.libresplit.LibreSplit.metainfo.xml \
+                    "${rpm_topdir}/SOURCES/"
+
+            - name: Install RPM build dependencies
+              run: |
+                  rpm_topdir="${RUNNER_TEMP}/rpmbuild"
+                  dnf --assumeyes builddep \
+                    -D "libresplit_version ${VERSION}" \
+                    -D "libresplit_release ${RPM_RELEASE}" \
+                    --spec "${rpm_topdir}/SPECS/libresplit.spec"
+
+            - name: Build RPM
+              run: |
+                  rpm_topdir="${RUNNER_TEMP}/rpmbuild"
+                  rpmbuild -bb \
+                    --define "_topdir ${rpm_topdir}" \
+                    --define "libresplit_version ${VERSION}" \
+                    --define "libresplit_release ${RPM_RELEASE}" \
+                    "${rpm_topdir}/SPECS/libresplit.spec"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,26 @@ jobs:
                   permission-contents: write
                   permission-workflows: write
 
+            - name: Reject existing release
+              env:
+                  GH_TOKEN: ${{ steps.release-token.outputs.token }}
+                  TAG: v${{ steps.inputs.outputs.version }}
+              run: |
+                  set -euo pipefail
+
+                  existing_release_ids="$(
+                    gh api \
+                      --paginate \
+                      -H "X-GitHub-Api-Version: 2026-03-10" \
+                      "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+                      --jq ".[] | select(.tag_name == \"${TAG}\") | .id"
+                  )"
+
+                  if [[ -n "${existing_release_ids}" ]]; then
+                    echo "${TAG} already exists." >&2
+                    exit 1
+                  fi
+
             - name: Create draft release
               id: draft
               uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,190 @@
+name: Release LibreSplit
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: LibreSplit version MAJOR.MINOR.PATCH
+                required: true
+                type: string
+            commit:
+                description: Full commit hash from main (defaults to current main)
+                required: false
+                type: string
+
+permissions: {}
+
+env:
+    RPM_RELEASE: "1"
+
+jobs:
+    prepare:
+        name: Prepare release
+        runs-on: ubuntu-24.04
+        environment: production
+        permissions:
+            contents: read
+        outputs:
+            packaging_sha: ${{ steps.inputs.outputs.packaging_sha }}
+            release_id: ${{ steps.draft.outputs.id }}
+            rpm_release: ${{ steps.inputs.outputs.rpm_release }}
+            source_sha: ${{ steps.inputs.outputs.source_sha }}
+            version: ${{ steps.inputs.outputs.version }}
+        steps:
+            - name: Check out main
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
+                  ref: main
+
+            - name: Resolve release inputs
+              id: inputs
+              env:
+                  COMMIT_INPUT: ${{ inputs.commit }}
+                  VERSION_INPUT: ${{ inputs.version }}
+              run: |
+                  set -euo pipefail
+
+                  version="$(
+                    printf '%s' "${VERSION_INPUT}" |
+                      sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+                  )"
+                  requested_sha="$(
+                    printf '%s' "${COMMIT_INPUT}" |
+                      sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+                  )"
+
+                  if [[ ! "${version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+                    echo "Version must be MAJOR.MINOR.PATCH." >&2
+                    exit 1
+                  fi
+
+                  if [[ -z "${requested_sha}" ]]; then
+                    source_sha="$(git rev-parse origin/main)"
+                  else
+                    if [[ ! "${requested_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                      echo "Commit must be a full commit hash from main." >&2
+                      exit 1
+                    fi
+
+                    source_sha="$(
+                      git rev-parse --verify --end-of-options "${requested_sha}^{commit}"
+                    )"
+
+                    if ! git merge-base --is-ancestor "${source_sha}" origin/main; then
+                      echo "Commit must belong to the current main branch." >&2
+                      exit 1
+                    fi
+                  fi
+
+                  packaging_sha="$(
+                    git ls-remote --exit-code \
+                      https://github.com/LibreSplit/rpm.libresplit.org.git \
+                      refs/heads/main |
+                      cut -f1
+                  )"
+
+                  echo "packaging_sha=${packaging_sha}" >> "${GITHUB_OUTPUT}"
+                  echo "rpm_release=${RPM_RELEASE}" >> "${GITHUB_OUTPUT}"
+                  echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
+                  echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+            - name: Create release token
+              id: release-token
+              uses: actions/create-github-app-token@v3
+              with:
+                  client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+                  private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+                  owner: LibreSplit
+                  repositories: LibreSplit
+                  permission-contents: write
+                  permission-workflows: write
+
+            - name: Create draft release
+              id: draft
+              uses: softprops/action-gh-release@v3
+              with:
+                  token: ${{ steps.release-token.outputs.token }}
+                  tag_name: v${{ steps.inputs.outputs.version }}
+                  target_commitish: ${{ steps.inputs.outputs.source_sha }}
+                  name: LibreSplit ${{ steps.inputs.outputs.version }}
+                  draft: true
+                  prerelease: false
+                  generate_release_notes: true
+
+    build:
+        name: Build release
+        needs: prepare
+        permissions:
+            contents: write
+        uses: ./.github/workflows/build.yml
+        with:
+            packaging_sha: ${{ needs.prepare.outputs.packaging_sha }}
+            rpm_release: ${{ needs.prepare.outputs.rpm_release }}
+            source_sha: ${{ needs.prepare.outputs.source_sha }}
+            version: ${{ needs.prepare.outputs.version }}
+
+    publish:
+        name: Publish release
+        needs: [prepare, build]
+        runs-on: ubuntu-24.04
+        environment: production
+        permissions:
+            actions: read
+            contents: write
+        steps:
+            - name: Download release artifacts
+              uses: actions/download-artifact@v7
+
+            - name: Upload release artifacts
+              uses: softprops/action-gh-release@v3
+              with:
+                  token: ${{ github.token }}
+                  tag_name: v${{ needs.prepare.outputs.version }}
+                  draft: true
+                  fail_on_unmatched_files: true
+                  files: |
+                      LibreSplit-${{ needs.prepare.outputs.version }}-standalone-x86_64/LibreSplit-${{ needs.prepare.outputs.version }}-standalone-x86_64.zip
+                      LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage/LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage
+                      LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage.zsync/LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage.zsync
+
+            - name: Create publication token
+              id: publication-token
+              uses: actions/create-github-app-token@v3
+              with:
+                  client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+                  private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+                  owner: LibreSplit
+                  repositories: rpm.libresplit.org
+                  permission-actions: write
+
+            - name: Publish RPM repository
+              env:
+                  GH_TOKEN: ${{ steps.publication-token.outputs.token }}
+                  ORIGIN_RUN_ID: ${{ github.run_id }}
+                  PACKAGING_SHA: ${{ needs.prepare.outputs.packaging_sha }}
+                  RELEASE_ID: ${{ needs.prepare.outputs.release_id }}
+                  RPM_RELEASE: ${{ needs.prepare.outputs.rpm_release }}
+                  SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+                  VERSION: ${{ needs.prepare.outputs.version }}
+              run: |
+                  downstream_run_id="$(
+                    gh api \
+                      --method POST \
+                      -H "X-GitHub-Api-Version: 2026-03-10" \
+                      repos/LibreSplit/rpm.libresplit.org/actions/workflows/publish.yml/dispatches \
+                      -f ref=main \
+                      -f "inputs[release_id]=${RELEASE_ID}" \
+                      -f "inputs[version]=${VERSION}" \
+                      -f "inputs[rpm_release]=${RPM_RELEASE}" \
+                      -f "inputs[source_sha]=${SOURCE_SHA}" \
+                      -f "inputs[packaging_sha]=${PACKAGING_SHA}" \
+                      -f "inputs[origin_run_id]=${ORIGIN_RUN_ID}" \
+                      --jq .workflow_run_id
+                  )"
+
+                  gh run watch \
+                    "${downstream_run_id}" \
+                    --exit-status \
+                    --repo LibreSplit/rpm.libresplit.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
         permissions:
             contents: read
         outputs:
-            packaging_sha: ${{ steps.inputs.outputs.packaging_sha }}
             release_id: ${{ steps.draft.outputs.id }}
             rpm_release: ${{ steps.inputs.outputs.rpm_release }}
             source_sha: ${{ steps.inputs.outputs.source_sha }}
@@ -78,14 +77,6 @@ jobs:
                     fi
                   fi
 
-                  packaging_sha="$(
-                    git ls-remote --exit-code \
-                      https://github.com/LibreSplit/rpm.libresplit.org.git \
-                      refs/heads/main |
-                      cut -f1
-                  )"
-
-                  echo "packaging_sha=${packaging_sha}" >> "${GITHUB_OUTPUT}"
                   echo "rpm_release=${RPM_RELEASE}" >> "${GITHUB_OUTPUT}"
                   echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
                   echo "version=${version}" >> "${GITHUB_OUTPUT}"
@@ -140,7 +131,6 @@ jobs:
             contents: write
         uses: ./.github/workflows/build.yml
         with:
-            packaging_sha: ${{ needs.prepare.outputs.packaging_sha }}
             rpm_release: ${{ needs.prepare.outputs.rpm_release }}
             source_sha: ${{ needs.prepare.outputs.source_sha }}
             version: ${{ needs.prepare.outputs.version }}
@@ -194,7 +184,6 @@ jobs:
               env:
                   GH_TOKEN: ${{ steps.publication-token.outputs.token }}
                   ORIGIN_RUN_ID: ${{ github.run_id }}
-                  PACKAGING_SHA: ${{ needs.prepare.outputs.packaging_sha }}
                   RELEASE_ID: ${{ needs.prepare.outputs.release_id }}
                   RPM_RELEASE: ${{ needs.prepare.outputs.rpm_release }}
                   SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
@@ -211,7 +200,6 @@ jobs:
                       -f "inputs[version]=${VERSION}" \
                       -f "inputs[rpm_release]=${RPM_RELEASE}" \
                       -f "inputs[source_sha]=${SOURCE_SHA}" \
-                      -f "inputs[packaging_sha]=${PACKAGING_SHA}" \
                       -f "inputs[origin_run_id]=${ORIGIN_RUN_ID}" \
                       --jq .workflow_run_id
                   )"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,210 +1,208 @@
 name: Release LibreSplit
 
 on:
-    workflow_dispatch:
-        inputs:
-            version:
-                description: LibreSplit version MAJOR.MINOR.PATCH
-                required: true
-                type: string
-            commit:
-                description: Full commit hash from main (defaults to current main)
-                required: false
-                type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: LibreSplit version MAJOR.MINOR.PATCH
+        required: true
+        type: string
+      commit:
+        description: Full commit hash from main (defaults to current main)
+        required: false
+        type: string
 
 permissions: {}
 
 env:
-    RPM_RELEASE: "1"
+  RPM_RELEASE: "1"
 
 jobs:
-    prepare:
-        name: Prepare release
-        runs-on: ubuntu-24.04
-        environment: production
-        permissions:
-            contents: read
-        outputs:
-            release_id: ${{ steps.draft.outputs.id }}
-            rpm_release: ${{ steps.inputs.outputs.rpm_release }}
-            source_sha: ${{ steps.inputs.outputs.source_sha }}
-            version: ${{ steps.inputs.outputs.version }}
-        steps:
-            - name: Check out main
-              uses: actions/checkout@v7
-              with:
-                  fetch-depth: 0
-                  persist-credentials: false
-                  ref: main
-
-            - name: Resolve release inputs
-              id: inputs
-              env:
-                  COMMIT_INPUT: ${{ inputs.commit }}
-                  VERSION_INPUT: ${{ inputs.version }}
-              run: |
-                  set -euo pipefail
-
-                  version="$(
-                    printf '%s' "${VERSION_INPUT}" |
-                      sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
-                  )"
-                  requested_sha="$(
-                    printf '%s' "${COMMIT_INPUT}" |
-                      sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
-                  )"
-
-                  if [[ ! "${version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-                    echo "Version must be MAJOR.MINOR.PATCH." >&2
-                    exit 1
-                  fi
-
-                  if [[ -z "${requested_sha}" ]]; then
-                    source_sha="$(git rev-parse origin/main)"
-                  else
-                    if [[ ! "${requested_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
-                      echo "Commit must be a full commit hash from main." >&2
-                      exit 1
-                    fi
-
-                    source_sha="$(
-                      git rev-parse --verify --end-of-options "${requested_sha}^{commit}"
-                    )"
-
-                    if ! git merge-base --is-ancestor "${source_sha}" origin/main; then
-                      echo "Commit must belong to the current main branch." >&2
-                      exit 1
-                    fi
-                  fi
-
-                  echo "rpm_release=${RPM_RELEASE}" >> "${GITHUB_OUTPUT}"
-                  echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
-                  echo "version=${version}" >> "${GITHUB_OUTPUT}"
-
-            - name: Create release token
-              id: release-token
-              uses: actions/create-github-app-token@v3
-              with:
-                  client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
-                  private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-                  owner: LibreSplit
-                  repositories: LibreSplit
-                  permission-contents: write
-                  permission-workflows: write
-
-            - name: Reject existing release
-              env:
-                  GH_TOKEN: ${{ steps.release-token.outputs.token }}
-                  TAG: v${{ steps.inputs.outputs.version }}
-              run: |
-                  set -euo pipefail
-
-                  existing_release_ids="$(
-                    gh api \
-                      --paginate \
-                      -H "X-GitHub-Api-Version: 2026-03-10" \
-                      "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
-                      --jq ".[] | select(.tag_name == \"${TAG}\") | .id"
-                  )"
-
-                  if [[ -n "${existing_release_ids}" ]]; then
-                    echo "${TAG} already exists." >&2
-                    exit 1
-                  fi
-
-            - name: Create draft release
-              id: draft
-              uses: softprops/action-gh-release@v3
-              with:
-                  token: ${{ steps.release-token.outputs.token }}
-                  tag_name: v${{ steps.inputs.outputs.version }}
-                  target_commitish: ${{ steps.inputs.outputs.source_sha }}
-                  name: LibreSplit ${{ steps.inputs.outputs.version }}
-                  draft: true
-                  prerelease: false
-                  generate_release_notes: true
-
-    build:
-        name: Build release
-        needs: prepare
-        permissions:
-            contents: write
-        uses: ./.github/workflows/build.yml
+  prepare:
+    name: Prepare release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      release_id: ${{ steps.draft.outputs.id }}
+      rpm_release: ${{ steps.inputs.outputs.rpm_release }}
+      source_sha: ${{ steps.inputs.outputs.source_sha }}
+      version: ${{ steps.inputs.outputs.version }}
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v7
         with:
-            rpm_release: ${{ needs.prepare.outputs.rpm_release }}
-            source_sha: ${{ needs.prepare.outputs.source_sha }}
-            version: ${{ needs.prepare.outputs.version }}
+          fetch-depth: 0
+          persist-credentials: false
+          ref: main
 
-    publish:
-        name: Publish release
-        needs: [prepare, build]
-        runs-on: ubuntu-24.04
-        environment: production
-        permissions:
-            actions: read
-            contents: write
-        steps:
-            - name: Download release artifacts
-              uses: actions/download-artifact@v7
+      - name: Resolve release inputs
+        id: inputs
+        env:
+          COMMIT_INPUT: ${{ inputs.commit }}
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
 
-            - name: Create release token
-              id: release-token
-              uses: actions/create-github-app-token@v3
-              with:
-                  client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
-                  private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-                  owner: LibreSplit
-                  repositories: LibreSplit
-                  permission-contents: write
-                  permission-workflows: write
+          version="$(
+            printf '%s' "${VERSION_INPUT}" |
+              sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+          )"
+          requested_sha="$(
+            printf '%s' "${COMMIT_INPUT}" |
+              sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+          )"
 
-            - name: Upload release artifacts
-              uses: softprops/action-gh-release@v3
-              with:
-                  token: ${{ steps.release-token.outputs.token }}
-                  tag_name: v${{ needs.prepare.outputs.version }}
-                  draft: true
-                  fail_on_unmatched_files: true
-                  files: |
-                      LibreSplit-${{ needs.prepare.outputs.version }}-standalone-x86_64/LibreSplit-${{ needs.prepare.outputs.version }}-standalone-x86_64.zip
-                      LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage/LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage
-                      LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage.zsync/LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage.zsync
+          if [[ ! "${version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Version must be MAJOR.MINOR.PATCH." >&2
+            exit 1
+          fi
 
-            - name: Create publication token
-              id: publication-token
-              uses: actions/create-github-app-token@v3
-              with:
-                  client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
-                  private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-                  owner: LibreSplit
-                  repositories: rpm.libresplit.org
-                  permission-actions: write
+          if [[ -z "${requested_sha}" ]]; then
+            source_sha="$(git rev-parse origin/main)"
+          else
+            if [[ ! "${requested_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "Commit must be a full commit hash from main." >&2
+              exit 1
+            fi
 
-            - name: Publish RPM repository
-              env:
-                  GH_TOKEN: ${{ steps.publication-token.outputs.token }}
-                  ORIGIN_RUN_ID: ${{ github.run_id }}
-                  RELEASE_ID: ${{ needs.prepare.outputs.release_id }}
-                  RPM_RELEASE: ${{ needs.prepare.outputs.rpm_release }}
-                  SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
-                  VERSION: ${{ needs.prepare.outputs.version }}
-              run: |
-                  downstream_run_id="$(
-                    gh api \
-                      --method POST \
-                      -H "X-GitHub-Api-Version: 2026-03-10" \
-                      repos/LibreSplit/rpm.libresplit.org/actions/workflows/publish.yml/dispatches \
-                      -F return_run_details=true \
-                      -f ref=main \
-                      -f "inputs[release_id]=${RELEASE_ID}" \
-                      -f "inputs[version]=${VERSION}" \
-                      -f "inputs[rpm_release]=${RPM_RELEASE}" \
-                      -f "inputs[source_sha]=${SOURCE_SHA}" \
-                      -f "inputs[origin_run_id]=${ORIGIN_RUN_ID}" \
-                      --jq .workflow_run_id
-                  )"
+            source_sha="$(
+              git rev-parse --verify --end-of-options "${requested_sha}^{commit}"
+            )"
 
-                  gh run watch \
-                    "${downstream_run_id}" \
-                    --exit-status \
-                    --repo LibreSplit/rpm.libresplit.org
+            if ! git merge-base --is-ancestor "${source_sha}" origin/main; then
+              echo "Commit must belong to the current main branch." >&2
+              exit 1
+            fi
+          fi
+
+          echo "rpm_release=${RPM_RELEASE}" >> "${GITHUB_OUTPUT}"
+          echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create release token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: LibreSplit
+          repositories: LibreSplit
+          permission-contents: write
+          permission-workflows: write
+
+      - name: Reject existing release
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+          TAG: v${{ steps.inputs.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          existing_release_ids="$(
+            gh api \
+              --paginate \
+              -H "X-GitHub-Api-Version: 2026-03-10" \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              --jq ".[] | select(.tag_name == \"${TAG}\") | .id"
+          )"
+
+          if [[ -n "${existing_release_ids}" ]]; then
+            echo "${TAG} already exists." >&2
+            exit 1
+          fi
+
+      - name: Create draft release
+        id: draft
+        uses: softprops/action-gh-release@v3
+        with:
+          token: ${{ steps.release-token.outputs.token }}
+          tag_name: v${{ steps.inputs.outputs.version }}
+          target_commitish: ${{ steps.inputs.outputs.source_sha }}
+          name: LibreSplit ${{ steps.inputs.outputs.version }}
+          draft: true
+          prerelease: false
+          generate_release_notes: true
+
+  build:
+    name: Build release
+    needs: prepare
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build.yml
+    with:
+      rpm_release: ${{ needs.prepare.outputs.rpm_release }}
+      source_sha: ${{ needs.prepare.outputs.source_sha }}
+      version: ${{ needs.prepare.outputs.version }}
+
+  publish:
+    name: Publish release
+    needs: [prepare, build]
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v7
+
+      - name: Create release token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: LibreSplit
+          repositories: LibreSplit
+          permission-contents: write
+          permission-workflows: write
+
+      - name: Upload release artifacts
+        uses: softprops/action-gh-release@v3
+        with:
+          token: ${{ steps.release-token.outputs.token }}
+          tag_name: v${{ needs.prepare.outputs.version }}
+          draft: true
+          fail_on_unmatched_files: true
+          files: |
+            LibreSplit-${{ needs.prepare.outputs.version }}-standalone-x86_64/LibreSplit-${{ needs.prepare.outputs.version }}-standalone-x86_64.zip
+            LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage/LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage
+            LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage.zsync/LibreSplit-${{ needs.prepare.outputs.version }}-x86_64.AppImage.zsync
+
+      - name: Create publication token
+        id: publication-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: LibreSplit
+          repositories: rpm.libresplit.org
+          permission-actions: write
+
+      - name: Publish RPM repository
+        env:
+          GH_TOKEN: ${{ steps.publication-token.outputs.token }}
+          ORIGIN_RUN_ID: ${{ github.run_id }}
+          RELEASE_ID: ${{ needs.prepare.outputs.release_id }}
+          RPM_RELEASE: ${{ needs.prepare.outputs.rpm_release }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          downstream_run_id="$(
+            gh api \
+              --method POST \
+              -H "X-GitHub-Api-Version: 2026-03-10" \
+              repos/LibreSplit/rpm.libresplit.org/actions/workflows/publish.yml/dispatches \
+              -F return_run_details=true \
+              -f ref=main \
+              -f "inputs[release_id]=${RELEASE_ID}" \
+              -f "inputs[version]=${VERSION}" \
+              -f "inputs[rpm_release]=${RPM_RELEASE}" \
+              -f "inputs[source_sha]=${SOURCE_SHA}" \
+              -f "inputs[origin_run_id]=${ORIGIN_RUN_ID}" \
+              --jq .workflow_run_id
+          )"
+
+          gh run watch \
+            "${downstream_run_id}" \
+            --exit-status \
+            --repo LibreSplit/rpm.libresplit.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,10 +137,21 @@ jobs:
             - name: Download release artifacts
               uses: actions/download-artifact@v7
 
+            - name: Create release token
+              id: release-token
+              uses: actions/create-github-app-token@v3
+              with:
+                  client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+                  private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+                  owner: LibreSplit
+                  repositories: LibreSplit
+                  permission-contents: write
+                  permission-workflows: write
+
             - name: Upload release artifacts
               uses: softprops/action-gh-release@v3
               with:
-                  token: ${{ github.token }}
+                  token: ${{ steps.release-token.outputs.token }}
                   tag_name: v${{ needs.prepare.outputs.version }}
                   draft: true
                   fail_on_unmatched_files: true
@@ -174,6 +185,7 @@ jobs:
                       --method POST \
                       -H "X-GitHub-Api-Version: 2026-03-10" \
                       repos/LibreSplit/rpm.libresplit.org/actions/workflows/publish.yml/dispatches \
+                      -F return_run_details=true \
                       -f ref=main \
                       -f "inputs[release_id]=${RELEASE_ID}" \
                       -f "inputs[version]=${VERSION}" \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ LibreSplit is a speedrun timer based on [urn](https://github.com/3snowp7im/urn) 
 
 ## Installation
 
+- Fedora/RHEL Based Systems
+
+    Download the RPM for your system and open it with your software manager:
+
+    - [x86_64](https://rpm.libresplit.org/libresplit.x86_64.rpm)
+    - [arm64](https://rpm.libresplit.org/libresplit.aarch64.rpm)
+
+    Or via command line:
+
+    ```sh
+    sudo dnf install "https://rpm.libresplit.org/libresplit.$(uname -m).rpm"
+    ```
+
 - Arch-based Distros
     - `yay libresplit-git`
     - `paru libresplit-git`
@@ -77,6 +90,18 @@ and also the following (optional) runtime dependencies:
 - `glib-networking` (for web split icons)
 
 Install the required dependencies:
+
+- Fedora/RHEL Based Systems
+
+    ```sh
+    sudo dnf install binutils gcc git gtk3-devel jansson-devel libX11-devel luajit-devel meson openssl-devel
+    ```
+
+    For optional dependencies:
+
+    ```sh
+    sudo dnf install glib-networking gvfs
+    ```
 
 - Debian-based systems
 

--- a/assets/rpm/libresplit.repo
+++ b/assets/rpm/libresplit.repo
@@ -1,0 +1,8 @@
+[libresplit]
+name=LibreSplit
+baseurl=https://rpm.libresplit.org/stable/$basearch/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://rpm.libresplit.org/RPM-GPG-KEY-libresplit
+skip_if_unavailable=0

--- a/assets/rpm/libresplit.spec
+++ b/assets/rpm/libresplit.spec
@@ -1,0 +1,73 @@
+%if %{undefined libresplit_version}
+%{error:The build must define libresplit_version as X.Y.Z}
+%endif
+%if %{undefined libresplit_release}
+%{error:The build must define libresplit_release as a positive integer}
+%endif
+
+Name:           libresplit
+Version:        %{libresplit_version}
+Release:        %{libresplit_release}
+Summary:        Free speedrun timer with auto splitting and load removal for Linux.
+License:        GPL-3.0-only
+URL:            https://libresplit.org/
+Source0:        %{name}-%{version}.tar.gz
+Source1:        libresplit.repo
+Source2:        org.libresplit.LibreSplit.metainfo.xml
+
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  appstream
+BuildRequires:  binutils
+BuildRequires:  desktop-file-utils
+BuildRequires:  gcc
+BuildRequires:  gtk3-devel
+BuildRequires:  jansson-devel
+BuildRequires:  libX11-devel
+BuildRequires:  luajit-devel
+BuildRequires:  meson
+BuildRequires:  openssl-devel
+
+Requires:       hicolor-icon-theme
+Recommends:     glib-networking
+Recommends:     gvfs
+
+%description
+LibreSplit is a speedrun timer based on urn that adds support for Lua-based auto
+splitters that are easy to port from ASL.
+
+%prep
+%autosetup -n %{name}-%{version}
+sed -i "s/version: 'pre-release'/version: '%{version}'/" meson.build
+grep -Fq "version: '%{version}'" meson.build
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+install -Dpm 0644 %{SOURCE2} \
+    %{buildroot}%{_metainfodir}/org.libresplit.LibreSplit.metainfo.xml
+install -Dpm 0644 %{SOURCE1} \
+    %{buildroot}%{_sysconfdir}/yum.repos.d/libresplit.repo
+
+%check
+desktop-file-validate \
+    %{buildroot}%{_datadir}/applications/libresplit.desktop
+appstreamcli validate --no-net \
+    %{buildroot}%{_metainfodir}/org.libresplit.LibreSplit.metainfo.xml
+
+%files
+%license %{_licensedir}/%{name}/LICENSE
+%doc %{_docdir}/%{name}/README.md
+%{_bindir}/libresplit
+%{_bindir}/libresplit-ctl
+%{_datadir}/applications/libresplit.desktop
+%{_datadir}/icons/hicolor/*/apps/libresplit.png
+%{_metainfodir}/org.libresplit.LibreSplit.metainfo.xml
+%config(noreplace) %{_sysconfdir}/yum.repos.d/libresplit.repo
+
+%changelog
+* Mon Aug 03 2026 LibreSplit <rpm@libresplit.org> - %{version}-%{release}
+- Add the initial LibreSplit RPM packaging policy.

--- a/assets/rpm/org.libresplit.LibreSplit.metainfo.xml
+++ b/assets/rpm/org.libresplit.LibreSplit.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.libresplit.LibreSplit</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <name>LibreSplit</name>
+  <summary>Free speedrun timer with auto splitting and load removal for Linux.</summary>
+  <developer id="org.libresplit">
+    <name>LibreSplit</name>
+  </developer>
+  <description>
+    <p>
+      LibreSplit is a speedrun timer based on urn that adds support for
+      Lua-based auto splitters that are easy to port from ASL.
+    </p>
+  </description>
+  <launchable type="desktop-id">libresplit.desktop</launchable>
+  <provides>
+    <binary>libresplit</binary>
+  </provides>
+  <url type="homepage">https://libresplit.org/</url>
+  <url type="bugtracker">https://github.com/LibreSplit/LibreSplit/issues</url>
+  <content_rating type="oars-1.1"/>
+</component>


### PR DESCRIPTION
Test builds have already ran in the following locations:
https://github.com/StarlitLuna/LibreSplit-test/actions/runs/31291004205
https://github.com/StarlitLuna/rpm.libresplit.org-test/actions/runs/31291074411

This adds a new release workflow and modifies the build and check workflows. The idea is that the normal nightly builds still happen as before and produce the nightly pre-release versions of that standalone zip, source, AppImage etc and skips the RPM builds. The build workflow can also be invoked with a specific version number for a stable release which produces stable versioned builds of all of the current builds including RPM builds (unsigned) in a draft release passed by the invocation.

The release workflow is a manual workflow that we can trigger when we want to create a stable release with semantic versioning. For our initial release I don't think LibreSplit is at 1.0 version readiness, but we can create a "stable" latest release of 0.1.0. When a release is run, the workflow creates a draft release, then it runs the build via invocation to upload the "stable" versioned builds to the draft release. Optionally you can provide a specific commit hash to build from for the new version instead of the main HEAD commit. Once the builds complete, the rpm signing workflow in the RPM repo is triggered to sign the RPMs and publish our repository with the new version. That also updates our draft release to the latest published release from the draft state.

The check workflow also adds a build step to ensure that a new PR will not break RPM builds. Before a release, we should make sure that the new RPM actually installs cleanly as well.