### PR TITLE
fix: Convert settings dialog from a gtk window to a gtk dialog.

### DIFF
--- a/src/gui/help_dialog.c
+++ b/src/gui/help_dialog.c
@@ -20,9 +20,10 @@ static void build_help_dialog(GtkApplication* app, gpointer data)
         return;
     }
 
-    GtkWidget* window = gtk_application_window_new(app);
+    GtkWindow* parent = gtk_application_get_active_window(app);
+    GtkWidget* window = gtk_dialog_new_with_buttons("About LibreSplit", parent, GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT, NULL, NULL);
+    gtk_window_set_application(GTK_WINDOW(window), app);
     help_window_singleton = window;
-    gtk_window_set_title(GTK_WINDOW(window), "About LibreSplit");
     gtk_window_set_default_size(GTK_WINDOW(window), 200, 320);
     gtk_window_set_resizable(GTK_WINDOW(window), FALSE);
 
@@ -64,7 +65,7 @@ static void build_help_dialog(GtkApplication* app, gpointer data)
     gtk_widget_set_halign(version_label, GTK_ALIGN_CENTER);
     gtk_container_add(GTK_CONTAINER(box), version_label);
 
-    gtk_container_add(GTK_CONTAINER(window), box);
+    gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(window))), box);
 
     GtkWidget* website_lnk = gtk_link_button_new_with_label("https://libresplit.org/", "Check out our website!");
     gtk_container_add(GTK_CONTAINER(box), website_lnk);

--- a/src/gui/settings_dialog.c
+++ b/src/gui/settings_dialog.c
@@ -178,9 +178,10 @@ static void build_settings_dialog(GtkApplication* app, gpointer data)
         return;
     }
 
-    GtkWidget* window = gtk_application_window_new(app);
+    GtkWindow* parent = gtk_application_get_active_window(app);
+    GtkWidget* window = gtk_dialog_new_with_buttons("LibreSplit Settings", parent, GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT, NULL, NULL);
+    gtk_window_set_application(GTK_WINDOW(window), app);
     settings_window_singleton = window;
-    gtk_window_set_title(GTK_WINDOW(window), "LibreSplit Settings");
     gtk_window_set_default_size(GTK_WINDOW(window), 500, 500);
     gtk_window_set_resizable(GTK_WINDOW(window), FALSE);
     g_signal_connect(window, "delete-event", G_CALLBACK(on_help_window_delete), NULL);
@@ -254,8 +255,8 @@ static void build_settings_dialog(GtkApplication* app, gpointer data)
     GtkWidget* save_btn = gtk_button_new_with_label("Save");
     g_signal_connect(save_btn, "clicked", G_CALLBACK(save_gui_settings), NULL);
     gtk_container_add(GTK_CONTAINER(main_box), save_btn);
-    gtk_container_add(GTK_CONTAINER(window), main_box);
-    gtk_widget_show_all(main_box);
+    gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(window))), main_box);
+    gtk_widget_show_all(window);
     gtk_window_present(GTK_WINDOW(window));
 }
 


### PR DESCRIPTION
Currently the settings dialog is its own gtk window. This is actively discouraged by the GTK documentation from what I saw as all gtk windows are expected to be top level windows. It also leads to the settings dialog being shown underneath the main window:

<img width="1254" height="1099" alt="image" src="https://github.com/user-attachments/assets/818b9158-bcd8-4e51-8dad-68f751cd10e5" />

Instead the settings dialog should be, well, a dialog. With this fix:

<img width="1119" height="1094" alt="image" src="https://github.com/user-attachments/assets/6e39c8aa-76eb-45b4-a1bf-8f0e84f6ee25" />