### PR TITLE
fix(window): fix undecorated window resize and drag, also fix decorations toggle for Wayland

### DIFF
--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -32,7 +32,7 @@ G_DEFINE_TYPE(LSApp, ls_app, GTK_TYPE_APPLICATION)
 
 G_DEFINE_TYPE(LSAppWindow, ls_app_window, GTK_TYPE_APPLICATION_WINDOW)
 
-static void set_window_decorations(LSAppWindow* win)
+void set_window_decorations(LSAppWindow* win)
 {
     gtk_window_set_decorated(GTK_WINDOW(win), win->opts.decorated);
 

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -32,6 +32,12 @@ G_DEFINE_TYPE(LSApp, ls_app, GTK_TYPE_APPLICATION)
 
 G_DEFINE_TYPE(LSAppWindow, ls_app_window, GTK_TYPE_APPLICATION_WINDOW)
 
+/**
+ * Sets whether or not the window should be decorated
+ * based on the user's preferences.
+ *
+ * @param win The current main app window
+ */
 void set_window_decorations(LSAppWindow* win)
 {
     gtk_window_set_decorated(GTK_WINDOW(win), win->opts.decorated);
@@ -48,6 +54,15 @@ void set_window_decorations(LSAppWindow* win)
 #endif
 }
 
+/**
+ * Called when the main application window is about to be drawn.
+ * Useful on Wayland where decoration calls require the GdkWindow
+ * to actually exist, meaning our earlier call on application start
+ * to set the initial user's decoration settings might not work.
+ *
+ * @param widget The application's main widget
+ * @param data unused
+ */
 static void ls_app_window_realize(GtkWidget* widget, gpointer data)
 {
     set_window_decorations(LS_APP_WINDOW(widget));
@@ -413,7 +428,7 @@ static void ls_app_window_init(LSAppWindow* win)
     g_signal_connect(win, "motion-notify-event",
         G_CALLBACK(handle_pointer_motion), NULL);
     g_signal_connect(win, "realize",
-        G_CALLBACK(ls_app_window_realize), win);
+        G_CALLBACK(ls_app_window_realize), NULL);
 
     // As a crash workaround, only enable global hotkeys if not on Wayland
     const bool is_wayland = getenv("WAYLAND_DISPLAY");

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -12,6 +12,11 @@
 #include "src/settings/settings.h"
 #include "src/settings/utils.h"
 #include "src/timer.h"
+
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
+
 #include <glib-object.h>
 #include <stdatomic.h>
 #include <stdio.h>
@@ -27,11 +32,32 @@ G_DEFINE_TYPE(LSApp, ls_app, GTK_TYPE_APPLICATION)
 
 G_DEFINE_TYPE(LSAppWindow, ls_app_window, GTK_TYPE_APPLICATION_WINDOW)
 
+static void set_window_decorations(LSAppWindow* win)
+{
+    gtk_window_set_decorated(GTK_WINDOW(win), win->opts.decorated);
+
+#ifdef GDK_WINDOWING_WAYLAND
+    GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(win));
+    if (window && GDK_IS_WAYLAND_WINDOW(window)) {
+        if (win->opts.decorated) {
+            gdk_wayland_window_announce_ssd(window);
+        } else {
+            gdk_wayland_window_announce_csd(window);
+        }
+    }
+#endif
+}
+
+static void ls_app_window_realize(GtkWidget* widget, gpointer data)
+{
+    set_window_decorations(LS_APP_WINDOW(widget));
+}
+
 void toggle_decorations(LSAppWindow* win)
 {
     LOG_DEBUG("Toggling window decorations");
-    gtk_window_set_decorated(GTK_WINDOW(win), !win->opts.decorated);
     win->opts.decorated = !win->opts.decorated;
+    set_window_decorations(win);
     cfg.libresplit.start_decorated.value.b = win->opts.decorated;
     config_save();
 }
@@ -163,7 +189,7 @@ void ls_app_activate(GApplication* app)
         }
     }
     atomic_store(&auto_splitter_enabled, cfg.libresplit.auto_splitter_enabled.value.b);
-    g_signal_connect(win, "button_press_event", G_CALLBACK(button_right_click), app);
+    g_signal_connect(win, "button_press_event", G_CALLBACK(handle_button_pressed), app);
 }
 
 void ls_app_open(GApplication* app,
@@ -362,8 +388,8 @@ static void ls_app_window_init(LSAppWindow* win)
     win->keybinds.skip_split = parse_keybind(cfg.keybinds.skip_split.value.s);
     win->keybinds.toggle_decorations = parse_keybind(cfg.keybinds.toggle_decorations.value.s);
     win->keybinds.toggle_win_on_top = parse_keybind(cfg.keybinds.toggle_win_on_top.value.s);
-    gtk_window_set_decorated(GTK_WINDOW(win), win->opts.decorated);
     gtk_window_set_keep_above(GTK_WINDOW(win), win->opts.win_on_top);
+    set_window_decorations(win);
 
     // Load theme
     LOG_DEBUG("Loading Theme...");
@@ -382,6 +408,8 @@ static void ls_app_window_init(LSAppWindow* win)
         G_CALLBACK(ls_app_window_destroy), NULL);
     g_signal_connect(win, "configure-event",
         G_CALLBACK(ls_app_window_resize), win);
+    g_signal_connect(win, "realize",
+        G_CALLBACK(ls_app_window_realize), win);
 
     // As a crash workaround, only enable global hotkeys if not on Wayland
     const bool is_wayland = getenv("WAYLAND_DISPLAY");

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -189,7 +189,7 @@ void ls_app_activate(GApplication* app)
         }
     }
     atomic_store(&auto_splitter_enabled, cfg.libresplit.auto_splitter_enabled.value.b);
-    g_signal_connect(win, "button_press_event", G_CALLBACK(handle_button_pressed), app);
+    g_signal_connect(win, "button-press-event", G_CALLBACK(handle_button_pressed), app);
 }
 
 void ls_app_open(GApplication* app,
@@ -370,6 +370,7 @@ static void ls_app_window_init(LSAppWindow* win)
     win->display = gdk_display_get_default();
     win->style = NULL;
     win->context_menu = NULL;
+    win->resize_cursor_hover = false;
 
     // make data path
     win->data_path[0] = '\0';
@@ -403,11 +404,14 @@ static void ls_app_window_init(LSAppWindow* win)
     win->game = 0;
     win->timer = 0;
 
+    gtk_widget_add_events(GTK_WIDGET(win), GDK_POINTER_MOTION_MASK);
     LOG_DEBUG("Connecting window signals...")
     g_signal_connect(win, "destroy",
         G_CALLBACK(ls_app_window_destroy), NULL);
     g_signal_connect(win, "configure-event",
         G_CALLBACK(ls_app_window_resize), win);
+    g_signal_connect(win, "motion-notify-event",
+        G_CALLBACK(handle_pointer_motion), NULL);
     g_signal_connect(win, "realize",
         G_CALLBACK(ls_app_window_realize), win);
 

--- a/src/gui/app_window.h
+++ b/src/gui/app_window.h
@@ -47,6 +47,8 @@ typedef struct _LSAppWindow {
     LSWelcomeBox* welcome_box;
     GtkWidget* box;
     GtkWidget* context_menu; /*!< The context menu */
+    bool resize_cursor_hover; /*!< True when the user is mousing over the resize edge of an undecorated window */
+    GdkWindowEdge resize_cursor_edge; /*!< The edge the user is mousing over */
     GList* components;
     GtkWidget* footer;
     GtkCssProvider* reset_style; /*!< The "reset rules" provider, will remove desktop theme rules */

--- a/src/gui/app_window.h
+++ b/src/gui/app_window.h
@@ -58,6 +58,7 @@ typedef struct _LSAppWindow {
     LSOpts opts; /*!< The window options */
 } LSAppWindow;
 
+void set_window_decorations(LSAppWindow* win);
 void toggle_decorations(LSAppWindow* win);
 void toggle_win_on_top(LSAppWindow* win);
 

--- a/src/gui/context_menu.c
+++ b/src/gui/context_menu.c
@@ -5,6 +5,120 @@
 #include "src/lasr/auto-splitter.h"
 #include <gtk/gtk.h>
 
+// standardized cross-platform cursor names
+static const char* const resize_cursors[] = {
+    [GDK_WINDOW_EDGE_NORTH_WEST] = "nwse-resize",
+    [GDK_WINDOW_EDGE_NORTH] = "ns-resize",
+    [GDK_WINDOW_EDGE_NORTH_EAST] = "nesw-resize",
+    [GDK_WINDOW_EDGE_WEST] = "ew-resize",
+    [GDK_WINDOW_EDGE_EAST] = "ew-resize",
+    [GDK_WINDOW_EDGE_SOUTH_WEST] = "nesw-resize",
+    [GDK_WINDOW_EDGE_SOUTH] = "ns-resize",
+    [GDK_WINDOW_EDGE_SOUTH_EAST] = "nwse-resize",
+};
+
+/**
+ * Get the target widget's top most parent window coordinates from the base event coordinates.
+ *
+ * @param widget The current event's widget
+ * @param window The current event's window
+ * @param event_x The initial event x-coordinate
+ * @param event_y The initial event y-coordinate
+ * @param window_x Reference to the output's window x-coordinate
+ * @param window_y Reference to the output's window y-coordinate
+ * @return bool whether or not the coordinates were retrieved succesfully
+ */
+static bool get_window_coordinates(GtkWidget* widget, GdkWindow* window, double event_x, double event_y, double* window_x, double* window_y)
+{
+    *window_x = event_x;
+    *window_y = event_y;
+    GdkWindow* target = gtk_widget_get_window(widget);
+
+    while (window && window != target) {
+        double parent_x;
+        double parent_y;
+
+        gdk_window_coords_to_parent(window, *window_x, *window_y, &parent_x, &parent_y);
+
+        *window_x = parent_x;
+        *window_y = parent_y;
+        window = gdk_window_get_effective_parent(window);
+    }
+
+    return window == target;
+}
+
+/**
+ * Determines which (if any) window edge the event is nearest
+ * and returns that edge to the GdkWindowEdge reference.
+ *
+ * @param widget The current event's widget
+ * @param window The current event's window
+ * @param x The event's x-coordinate
+ * @param y The event's y-coordinate
+ * @param edge A reference to the GdkWindowEdge to save the value to
+ * @return bool Whether or not an edge was detected
+ */
+static bool get_window_edge(GtkWidget* widget, GdkWindow* window, double x, double y, GdkWindowEdge* edge)
+{
+    int width = gtk_widget_get_allocated_width(widget);
+    int height = gtk_widget_get_allocated_height(widget);
+    double window_x;
+    double window_y;
+
+    if (!get_window_coordinates(widget, window, x, y, &window_x, &window_y)) {
+        return false;
+    }
+
+    bool left = window_x < WINDOW_PAD;
+    bool right = window_x >= width - WINDOW_PAD;
+    bool top = window_y < WINDOW_PAD;
+    bool bot = window_y >= height - WINDOW_PAD;
+
+    if (top && left) {
+        *edge = GDK_WINDOW_EDGE_NORTH_WEST;
+    } else if (top && right) {
+        *edge = GDK_WINDOW_EDGE_NORTH_EAST;
+    } else if (bot && left) {
+        *edge = GDK_WINDOW_EDGE_SOUTH_WEST;
+    } else if (bot && right) {
+        *edge = GDK_WINDOW_EDGE_SOUTH_EAST;
+    } else if (top) {
+        *edge = GDK_WINDOW_EDGE_NORTH;
+    } else if (bot) {
+        *edge = GDK_WINDOW_EDGE_SOUTH;
+    } else if (left) {
+        *edge = GDK_WINDOW_EDGE_WEST;
+    } else if (right) {
+        *edge = GDK_WINDOW_EDGE_EAST;
+    } else {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Handles left mouse button clicks. We first detect if the mouse is over the very edge of the window
+ * if it is, then the click is determined to be for resizing the window and window resizing is handled.
+ * Otherwise, the event is interpreted to be for moving the window itself.
+ *
+ * @param widget The widget that was left clicked.
+ * @param event The click event, containing which button was used to click.
+ */
+void button_left_click(GtkWidget* widget, GdkEventButton* event)
+{
+    GdkWindowEdge edge;
+
+    // If the window is decorated then we should only ever worry about handling in app moves
+    if (gtk_window_get_decorated(GTK_WINDOW(widget)) || !get_window_edge(widget, event->window, event->x, event->y, &edge)) {
+        gtk_window_begin_move_drag(GTK_WINDOW(widget), event->button, event->x_root, event->y_root, event->time);
+        return;
+    }
+
+    gtk_window_begin_resize_drag(GTK_WINDOW(widget), edge, event->button, event->x_root, event->y_root, event->time);
+}
+
 /**
  * Creates the Context Menu.
  *
@@ -13,14 +127,9 @@
  */
 void button_right_click(GdkEventButton* event, gpointer app)
 {
-    GList* windows;
-    LSAppWindow* win;
-    windows = gtk_application_get_windows(GTK_APPLICATION(app));
-    if (windows) {
-        win = LS_APP_WINDOW(windows->data);
-    } else {
-        win = ls_app_window_new(LS_APP(app));
-    }
+    GList* windows = gtk_application_get_windows(GTK_APPLICATION(app));
+    LSAppWindow* win = windows ? LS_APP_WINDOW(windows->data) : ls_app_window_new(LS_APP(app));
+
     if (win->context_menu == NULL) {
         GtkWidget* menu = gtk_menu_new();
         GtkWidget* menu_open_splits = gtk_menu_item_new_with_label("Open Splits");
@@ -79,7 +188,7 @@ void button_right_click(GdkEventButton* event, gpointer app)
  * GDK_BUTTON_PRIMARY - Left mouse button click, used for moving the window
  * GDK_BUTTON_SECONDARY - Right mouse button click, display right click context menu
  *
- * @param widget The widget that was right clicked. Not used here.
+ * @param widget The widget that was right clicked.
  * @param event The click event, containing which button was used to click.
  * @param app Pointer to the LibreSplit application.
  * @return gboolean TRUE when a supported event is handled, FALSE otherwise.
@@ -88,11 +197,73 @@ gboolean handle_button_pressed(GtkWidget* widget, GdkEventButton* event, gpointe
 {
     switch (event->button) {
         case GDK_BUTTON_PRIMARY:
-            gtk_window_begin_move_drag(GTK_WINDOW(widget), event->button, event->x_root, event->y_root, event->time);
+            button_left_click(widget, event);
             return TRUE;
         case GDK_BUTTON_SECONDARY:
             button_right_click(event, app);
             return TRUE;
+    }
+
+    return FALSE;
+}
+
+/**
+ * Determines if the user's pointer is hovering over the application's edge
+ * and adjusts the cursor accordingly to display resize cursors instead of the default
+ * to indicate that the window is resizable and in which direction(s).
+ *
+ * This function does nothing when decorations are enabled as resizing is
+ * left to the decorations to handle.
+ *
+ * Always returns FALSE as motion handling is not terminal.
+ * This allows the signal to continue propagating.
+ *
+ * @param widget The widget that was hovered on
+ * @param event The hover event, containing the pointer's coordinates
+ * @param data not used
+ * @return FALSE
+ */
+gboolean handle_pointer_motion(GtkWidget* widget, GdkEventMotion* event, gpointer data)
+{
+    LSAppWindow* win = LS_APP_WINDOW(widget);
+    GdkWindow* window = gtk_widget_get_window(widget);
+
+    if (win->opts.hide_cursor) {
+        win->resize_cursor_hover = false;
+        return FALSE;
+    }
+
+    // if decorations enabled, decorations handle resize
+    if (gtk_window_get_decorated(GTK_WINDOW(widget))) {
+        if (win->resize_cursor_hover) {
+            gdk_window_set_cursor(window, NULL);
+            win->resize_cursor_hover = false;
+        }
+
+        return FALSE;
+    }
+
+    GdkCursor* cursor = NULL;
+    GdkWindowEdge edge;
+
+    if (get_window_edge(widget, event->window, event->x, event->y, &edge)) {
+        if (win->resize_cursor_hover && win->resize_cursor_edge == edge) {
+            return FALSE;
+        }
+
+        cursor = gdk_cursor_new_from_name(gtk_widget_get_display(widget), resize_cursors[edge]);
+    } else if (!win->resize_cursor_hover) {
+        return FALSE;
+    }
+
+    gdk_window_set_cursor(window, cursor);
+    win->resize_cursor_hover = cursor != NULL;
+    if (win->resize_cursor_hover) {
+        win->resize_cursor_edge = edge;
+    }
+
+    if (cursor) {
+        g_object_unref(cursor);
     }
 
     return FALSE;

--- a/src/gui/context_menu.c
+++ b/src/gui/context_menu.c
@@ -8,72 +8,92 @@
 /**
  * Creates the Context Menu.
  *
+ * @param event The click event, containing which button was used to click.
+ * @param app Pointer to the LibreSplit application.
+ */
+void button_right_click(GdkEventButton* event, gpointer app)
+{
+    GList* windows;
+    LSAppWindow* win;
+    windows = gtk_application_get_windows(GTK_APPLICATION(app));
+    if (windows) {
+        win = LS_APP_WINDOW(windows->data);
+    } else {
+        win = ls_app_window_new(LS_APP(app));
+    }
+    if (win->context_menu == NULL) {
+        GtkWidget* menu = gtk_menu_new();
+        GtkWidget* menu_open_splits = gtk_menu_item_new_with_label("Open Splits");
+        GtkWidget* menu_save_splits = gtk_menu_item_new_with_label("Save Splits");
+        GtkWidget* menu_open_auto_splitter = gtk_menu_item_new_with_label("Open Auto Splitter");
+        GtkWidget* menu_enable_auto_splitter = gtk_check_menu_item_new_with_label("Enable Auto Splitter");
+        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menu_enable_auto_splitter), atomic_load(&auto_splitter_enabled));
+        GtkWidget* menu_enable_win_on_top = gtk_check_menu_item_new_with_label("Always on Top");
+        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menu_enable_win_on_top), win->opts.win_on_top);
+        GtkWidget* menu_reload = gtk_menu_item_new_with_label("Reload");
+        GtkWidget* menu_close = gtk_menu_item_new_with_label("Close");
+        GtkWidget* menu_settings = gtk_menu_item_new_with_label("Settings");
+        GtkWidget* menu_about = gtk_menu_item_new_with_label("About and help");
+        GtkWidget* menu_quit = gtk_menu_item_new_with_label("Quit");
+
+        // Add the menu items to the menu
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_open_splits);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_save_splits);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_open_auto_splitter);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_enable_auto_splitter);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_reload);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_close);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_enable_win_on_top);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_settings);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_about);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_quit);
+
+        // Attach the callback functions to the menu items
+        g_signal_connect(menu_open_splits, "activate", G_CALLBACK(open_activated), app);
+        g_signal_connect(menu_save_splits, "activate", G_CALLBACK(save_activated), app);
+        g_signal_connect(menu_open_auto_splitter, "activate", G_CALLBACK(open_auto_splitter), app);
+        g_signal_connect(menu_enable_auto_splitter, "toggled", G_CALLBACK(toggle_auto_splitter), NULL);
+        g_signal_connect(menu_enable_win_on_top, "toggled", G_CALLBACK(menu_toggle_win_on_top), app);
+        g_signal_connect(menu_reload, "activate", G_CALLBACK(reload_activated), app);
+        g_signal_connect(menu_close, "activate", G_CALLBACK(close_activated), app);
+        g_signal_connect(menu_settings, "activate", G_CALLBACK(show_settings_dialog), app);
+        g_signal_connect(menu_about, "activate", G_CALLBACK(show_help_dialog), app);
+        g_signal_connect(menu_quit, "activate", G_CALLBACK(quit_activated), app);
+
+        win->context_menu = menu;
+    }
+
+    gtk_widget_show_all(win->context_menu);
+    gtk_menu_popup_at_pointer(GTK_MENU(win->context_menu), (GdkEvent*)event);
+}
+
+/**
+ * Event handler for a button being pressed on the main window.
+ * This function delegates supported operations to their respective handler
+ * depending on their buttons.
+ *
+ * GDK_BUTTON_PRIMARY - Left mouse button click, used for moving the window
+ * GDK_BUTTON_SECONDARY - Right mouse button click, display right click context menu
+ *
  * @param widget The widget that was right clicked. Not used here.
  * @param event The click event, containing which button was used to click.
  * @param app Pointer to the LibreSplit application.
- *
- * @return True if the click was done with the RMB (and a context menu was shown), False otherwise.
+ * @return gboolean TRUE when a supported event is handled, FALSE otherwise.
  */
-gboolean button_right_click(GtkWidget* widget, GdkEventButton* event, gpointer app)
+gboolean handle_button_pressed(GtkWidget* widget, GdkEventButton* event, gpointer app)
 {
-    if (event->button == GDK_BUTTON_SECONDARY) {
-        GList* windows;
-        LSAppWindow* win;
-        windows = gtk_application_get_windows(GTK_APPLICATION(app));
-        if (windows) {
-            win = LS_APP_WINDOW(windows->data);
-        } else {
-            win = ls_app_window_new(LS_APP(app));
-        }
-        if (win->context_menu == NULL) {
-            GtkWidget* menu = gtk_menu_new();
-            GtkWidget* menu_open_splits = gtk_menu_item_new_with_label("Open Splits");
-            GtkWidget* menu_save_splits = gtk_menu_item_new_with_label("Save Splits");
-            GtkWidget* menu_open_auto_splitter = gtk_menu_item_new_with_label("Open Auto Splitter");
-            GtkWidget* menu_enable_auto_splitter = gtk_check_menu_item_new_with_label("Enable Auto Splitter");
-            gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menu_enable_auto_splitter), atomic_load(&auto_splitter_enabled));
-            GtkWidget* menu_enable_win_on_top = gtk_check_menu_item_new_with_label("Always on Top");
-            gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menu_enable_win_on_top), win->opts.win_on_top);
-            GtkWidget* menu_reload = gtk_menu_item_new_with_label("Reload");
-            GtkWidget* menu_close = gtk_menu_item_new_with_label("Close");
-            GtkWidget* menu_settings = gtk_menu_item_new_with_label("Settings");
-            GtkWidget* menu_about = gtk_menu_item_new_with_label("About and help");
-            GtkWidget* menu_quit = gtk_menu_item_new_with_label("Quit");
-
-            // Add the menu items to the menu
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_open_splits);
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_save_splits);
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_open_auto_splitter);
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_enable_auto_splitter);
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_reload);
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_close);
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_enable_win_on_top);
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_settings);
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_about);
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
-            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_quit);
-
-            // Attach the callback functions to the menu items
-            g_signal_connect(menu_open_splits, "activate", G_CALLBACK(open_activated), app);
-            g_signal_connect(menu_save_splits, "activate", G_CALLBACK(save_activated), app);
-            g_signal_connect(menu_open_auto_splitter, "activate", G_CALLBACK(open_auto_splitter), app);
-            g_signal_connect(menu_enable_auto_splitter, "toggled", G_CALLBACK(toggle_auto_splitter), NULL);
-            g_signal_connect(menu_enable_win_on_top, "toggled", G_CALLBACK(menu_toggle_win_on_top), app);
-            g_signal_connect(menu_reload, "activate", G_CALLBACK(reload_activated), app);
-            g_signal_connect(menu_close, "activate", G_CALLBACK(close_activated), app);
-            g_signal_connect(menu_settings, "activate", G_CALLBACK(show_settings_dialog), app);
-            g_signal_connect(menu_about, "activate", G_CALLBACK(show_help_dialog), app);
-            g_signal_connect(menu_quit, "activate", G_CALLBACK(quit_activated), app);
-
-            win->context_menu = menu;
-        }
-
-        gtk_widget_show_all(win->context_menu);
-        gtk_menu_popup_at_pointer(GTK_MENU(win->context_menu), (GdkEvent*)event);
-        return TRUE;
+    switch (event->button) {
+        case GDK_BUTTON_PRIMARY:
+            gtk_window_begin_move_drag(GTK_WINDOW(widget), event->button, event->x_root, event->y_root, event->time);
+            return TRUE;
+        case GDK_BUTTON_SECONDARY:
+            button_right_click(event, app);
+            return TRUE;
     }
+
     return FALSE;
 }

--- a/src/gui/context_menu.h
+++ b/src/gui/context_menu.h
@@ -2,4 +2,5 @@
 
 #include <gtk/gtk.h>
 
-gboolean button_right_click(GtkWidget* widget, GdkEventButton* event, gpointer app);
+void button_right_click(GdkEventButton* event, gpointer app);
+gboolean handle_button_pressed(GtkWidget* widget, GdkEventButton* event, gpointer app);

--- a/src/gui/context_menu.h
+++ b/src/gui/context_menu.h
@@ -2,5 +2,7 @@
 
 #include <gtk/gtk.h>
 
+void button_left_click(GtkWidget* widget, GdkEventButton* event);
 void button_right_click(GdkEventButton* event, gpointer app);
 gboolean handle_button_pressed(GtkWidget* widget, GdkEventButton* event, gpointer app);
+gboolean handle_pointer_motion(GtkWidget* widget, GdkEventMotion* event, gpointer data);

--- a/src/gui/settings_dialog.c
+++ b/src/gui/settings_dialog.c
@@ -1,3 +1,4 @@
+#include "app_window.h"
 #include "settings_dialog.h"
 #include "src/logging.h"
 #include "src/settings/definitions.h"
@@ -123,7 +124,7 @@ bool on_entry_clear_press(GtkEntry* widget, GtkEntryIconPosition icon_pos, GdkEv
     return TRUE;
 }
 
-static void save_gui_settings(GSimpleAction* action, GVariant* parameter, gpointer app)
+static void save_gui_settings(GtkButton* button, gpointer app)
 {
     LOG_INFO("Saving settings from the GUI...");
     size_t settings_number = enumerate_settings(cfg);
@@ -154,7 +155,12 @@ static void save_gui_settings(GSimpleAction* action, GVariant* parameter, gpoint
         }
     }
     // Call the normal save_settings thing
-    config_save();
+    if (config_save()) {
+        // on success, set decorations in case the setting changed.
+        LSAppWindow* win = LS_APP_WINDOW(app);
+        win->opts.decorated = cfg.libresplit.start_decorated.value.b;
+        set_window_decorations(win);
+    }
 }
 
 static void set_widget_defaults(GtkWidget* obj)
@@ -258,7 +264,7 @@ static void build_settings_dialog(GtkApplication* app, gpointer data)
     }
     gtk_container_add(GTK_CONTAINER(main_box), tabs);
     GtkWidget* save_btn = gtk_button_new_with_label("Save");
-    g_signal_connect(save_btn, "clicked", G_CALLBACK(save_gui_settings), NULL);
+    g_signal_connect(save_btn, "clicked", G_CALLBACK(save_gui_settings), parent);
     gtk_container_add(GTK_CONTAINER(main_box), save_btn);
     gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(window))), main_box);
     gtk_widget_show_all(window);

--- a/src/gui/settings_dialog.c
+++ b/src/gui/settings_dialog.c
@@ -1,5 +1,5 @@
-#include "app_window.h"
 #include "settings_dialog.h"
+#include "app_window.h"
 #include "src/logging.h"
 #include "src/settings/definitions.h"
 #include "src/settings/settings.h"


### PR DESCRIPTION
This PR adds direct decorations negotiations with Wayland when Wayland is present. Since Wayland does not handle `gtk_window_set_decorated` we need to talk to Wayland directly to enable/disable decorations. If Wayland is not present then this should be no different to our current handling, just through `gtk_window_set_decorated` which X11 does support I believe.

This PR also adds left mouse click button handling and motion events to allow the window to be draggable and resizable without decorations.

I also noticed that the settings dialog's save button's clicked signal handler has an incorrect signature. So I fixed that as well. It should be `GtkButton* self, gpointer user_data` per the gtk documentation:

https://docs.gtk.org/gtk3/signal.Button.clicked.html

so I changed `save_gui_settings` to `static void save_gui_settings(GtkButton* button, gpointer app)` and I added a ref to the parent window so that saving settings can also update window decorations if the setting for it changes.

[Screencast_20260814_051405.webm](https://github.com/user-attachments/assets/0cde1f66-95eb-487b-ba25-8a7390d1be50)
