### PR TITLE
fix(context-menu): Add new class to help with context menu

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -18,8 +18,9 @@ See the [GTK 4 CSS properties documentation](https://docs.gtk.org/gtk4/css-prope
 
 | LibreSplit CSS classes        | Explanation Where needed                                                                                                                                 |
 | ----------------------------- | -----------------------------------------------                                                                                                          |
-| `.window`                     | Any window of LibreSplit (editing this class might affect other LibreSplit windows)                                                                      |
-| `.window.main-window`         | LibreSplit's main timer window (this won't influence other LibreSplit windows)                                                                           |
+| `window`                      | Any window of LibreSplit (editing this class might affect other LibreSplit windows)                                                                      |
+| `.window.main-window`         | LibreSplit's main timer window - think of this like the main `<body>` of a standard webpage                                                              |
+| `.libresplit-content`         | LibreSplit's timer content container - this is like the top level `<div>` element who's parent is `<body>` that all the components are a descendant of   |
 | `.header`                     | The header, containing title and attempt counters                                                                                                        |
 | `.title`                      | The title of the category (set in the splits json file)                                                                                                  |
 | `.attempt-count`              | Counter for attempts in top right corner (#attempts_finished / attempts_total)                                                                           |
@@ -76,7 +77,7 @@ A more complex example: if your split is named "Space Station (Part 1)", the CSS
 
 ### How do I hide a section of LibreSplit?
 
-GTK does not have a built-in way of hiding pieces of the interface, but you can hide most items by setting the font-size to zero. For instance:
+GTK CSS does not have a built-in way of hiding pieces of the interface, but you can hide most items by setting the font-size to zero. For instance:
 
 ```css
 .segment-pb, .segment-best{

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -22,8 +22,6 @@
 
 extern atomic_bool exit_requested; /*!< Set to 1 when LibreSplit is exiting */
 
-static void ls_app_window_size_allocate(GtkWidget* widget, int width, int height, int baseline);
-
 static void ls_app_init(LSApp* app)
 {
 }
@@ -215,11 +213,17 @@ static void ls_app_class_init(LSAppClass* class)
     G_APPLICATION_CLASS(class)->open = ls_app_open;
 }
 
-static void ls_app_window_class_init(LSAppWindowClass* class)
-{
-    GTK_WIDGET_CLASS(class)->size_allocate = ls_app_window_size_allocate;
-}
-
+/**
+ * @brief Keeps the context menu sized and positioned correctly during application layout.
+ *
+ * When a manual popover's parent is allocated, the popover must update its allocation as well.
+ * This chains the window's normal allocation with the context menu if it exists.
+ *
+ * @param widget The application window
+ * @param width The window's allocated width
+ * @param height The window's allocated height
+ * @param baseline The window's allocated baseline (-1 if there is none)
+ */
 static void ls_app_window_size_allocate(GtkWidget* widget, int width, int height, int baseline)
 {
     // This is the GtkApplicationWindow size allocate, not our appwindow
@@ -228,6 +232,11 @@ static void ls_app_window_size_allocate(GtkWidget* widget, int width, int height
     if (win->context_menu != NULL) {
         gtk_popover_present(GTK_POPOVER(win->context_menu));
     }
+}
+
+static void ls_app_window_class_init(LSAppWindowClass* class)
+{
+    GTK_WIDGET_CLASS(class)->size_allocate = ls_app_window_size_allocate;
 }
 
 /**

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -22,6 +22,8 @@
 
 extern atomic_bool exit_requested; /*!< Set to 1 when LibreSplit is exiting */
 
+static void ls_app_window_size_allocate(GtkWidget* widget, int width, int height, int baseline);
+
 static void ls_app_init(LSApp* app)
 {
 }
@@ -215,6 +217,17 @@ static void ls_app_class_init(LSAppClass* class)
 
 static void ls_app_window_class_init(LSAppWindowClass* class)
 {
+    GTK_WIDGET_CLASS(class)->size_allocate = ls_app_window_size_allocate;
+}
+
+static void ls_app_window_size_allocate(GtkWidget* widget, int width, int height, int baseline)
+{
+    // This is the GtkApplicationWindow size allocate, not our appwindow
+    GTK_WIDGET_CLASS(ls_app_window_parent_class)->size_allocate(widget, width, height, baseline);
+    LSAppWindow* win = LS_APP_WINDOW(widget);
+    if (win->context_menu != NULL) {
+        gtk_popover_present(GTK_POPOVER(win->context_menu));
+    }
 }
 
 /**
@@ -432,6 +445,7 @@ static void ls_app_window_init(LSAppWindow* win)
 
     LOG_DEBUG("Creating the main window...");
     win->container = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    add_class(win->container, "libresplit-content");
     gtk_widget_set_margin_top(win->container, WINDOW_PAD);
     gtk_widget_set_margin_bottom(win->container, WINDOW_PAD);
     gtk_widget_set_vexpand(win->container, TRUE);

--- a/src/gui/theming.c
+++ b/src/gui/theming.c
@@ -13,7 +13,7 @@ static inline size_t fallback_css_data_len(void)
     return (size_t)((uintptr_t)_binary____src_fallback_css_end - (uintptr_t)_binary____src_fallback_css_start);
 }
 
-static const char reset_rules[] = ".window.main-window{all:unset;}\n"
+static const char reset_rules[] = ".window.main-window{ all: unset; }\n"
                                   ".window.main-window .libresplit-content,\n"
                                   ".window.main-window .libresplit-content * { all: unset; }";
 

--- a/src/gui/theming.c
+++ b/src/gui/theming.c
@@ -13,7 +13,9 @@ static inline size_t fallback_css_data_len(void)
     return (size_t)((uintptr_t)_binary____src_fallback_css_end - (uintptr_t)_binary____src_fallback_css_start);
 }
 
-static const char reset_rules[] = ".window.main-window{all:unset;}\n.window.main-window *{all:unset;}";
+static const char reset_rules[] = ".window.main-window{all:unset;}\n"
+                                  ".window.main-window .libresplit-content,\n"
+                                  ".window.main-window .libresplit-content * { all: unset; }";
 
 /**
  * Captures CSS loading errors the same way GTK 3's GError parameter did.


### PR DESCRIPTION
In GTK 4 `GtkPopoverMenu` (replaces `GtkMenu`)  is not detached like `GtkMenu` was, it's a child of the main window which means it matches the `.main-window *` selector and therefore kills all styling on the context menu. So instead of unsetting everything under the main-window for theming, add a new class for the actual window that we want to theme and apply the unset to that.

Before:
<img width="565" height="743" alt="cm1" src="https://github.com/user-attachments/assets/9c1b250d-1f27-45cd-a935-dabfe383f72a" />

After:
<img width="571" height="926" alt="image" src="https://github.com/user-attachments/assets/e56f614d-dd55-47a1-bf5e-d2f2885de8b8" />
