### PR TITLE
fix: application id naming convention

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,9 +132,9 @@ jobs:
                   fi
 
                   mkdir -p AppDir/usr/share/applications
-                  cp assets/libresplit.desktop AppDir/
-                  cp assets/libresplit.desktop AppDir/usr/share/applications/
-                  sed -i 's/^Exec=.*/Exec=AppRun/' AppDir/libresplit.desktop
+                  cp assets/org.libresplit.LibreSplit.desktop AppDir/
+                  cp assets/org.libresplit.LibreSplit.desktop AppDir/usr/share/applications/
+                  sed -i 's/^Exec=.*/Exec=AppRun/' AppDir/org.libresplit.LibreSplit.desktop
                   cp assets/appimage.sh AppDir/AppRun
                   cp assets/icons/libresplit-256.png AppDir/libresplit.png
                   chmod +x AppDir/AppRun
@@ -177,7 +177,7 @@ jobs:
 
                   LDAI_OUTPUT="${APPIMAGE_NAME}" \
                   LDAI_UPDATE_INFORMATION="gh-releases-zsync|${{ github.repository_owner }}|LibreSplit|${UPDATE_CHANNEL}|LibreSplit-*-${ARCH}.AppImage.zsync" \
-                  "./linuxdeploy-${ARCH}.AppImage" --appdir AppDir --desktop-file AppDir/libresplit.desktop --icon-file AppDir/libresplit.png --output appimage
+                  "./linuxdeploy-${ARCH}.AppImage" --appdir AppDir --desktop-file AppDir/org.libresplit.LibreSplit.desktop --icon-file AppDir/libresplit.png --output appimage
 
                   if ! find AppDir -type f -name 'libgtk-4.so.1*' -print -quit | grep -q .; then
                     echo "::error::The AppImage does not contain GTK 4"

--- a/assets/org.libresplit.LibreSplit.desktop
+++ b/assets/org.libresplit.LibreSplit.desktop
@@ -2,5 +2,6 @@
 Name=LibreSplit
 Exec=libresplit
 Icon=libresplit
+StartupWMClass=libresplit
 Type=Application
 Categories=GTK;GNOME;Utility;

--- a/assets/rpm/libresplit.spec
+++ b/assets/rpm/libresplit.spec
@@ -54,7 +54,7 @@ install -Dpm 0644 %{SOURCE1} \
 
 %check
 desktop-file-validate \
-    %{buildroot}%{_datadir}/applications/libresplit.desktop
+    %{buildroot}%{_datadir}/applications/org.libresplit.LibreSplit.desktop
 appstreamcli validate --no-net \
     %{buildroot}%{_metainfodir}/org.libresplit.LibreSplit.metainfo.xml
 
@@ -63,8 +63,9 @@ appstreamcli validate --no-net \
 %doc %{_docdir}/%{name}/README.md
 %{_bindir}/libresplit
 %{_bindir}/libresplit-ctl
-%{_datadir}/applications/libresplit.desktop
+%{_datadir}/applications/org.libresplit.LibreSplit.desktop
 %{_datadir}/icons/hicolor/*/apps/libresplit.png
+${_datadir}/icons/hicolor/scalable/apps/libresplit.svg
 %{_metainfodir}/org.libresplit.LibreSplit.metainfo.xml
 %config(noreplace) %{_sysconfdir}/yum.repos.d/libresplit.repo
 

--- a/assets/rpm/libresplit.spec
+++ b/assets/rpm/libresplit.spec
@@ -65,7 +65,7 @@ appstreamcli validate --no-net \
 %{_bindir}/libresplit-ctl
 %{_datadir}/applications/org.libresplit.LibreSplit.desktop
 %{_datadir}/icons/hicolor/*/apps/libresplit.png
-${_datadir}/icons/hicolor/scalable/apps/libresplit.svg
+%{_datadir}/icons/hicolor/scalable/apps/libresplit.svg
 %{_metainfodir}/org.libresplit.LibreSplit.metainfo.xml
 %config(noreplace) %{_sysconfdir}/yum.repos.d/libresplit.repo
 

--- a/assets/rpm/org.libresplit.LibreSplit.metainfo.xml
+++ b/assets/rpm/org.libresplit.LibreSplit.metainfo.xml
@@ -14,7 +14,7 @@
       Lua-based auto splitters that are easy to port from ASL.
     </p>
   </description>
-  <launchable type="desktop-id">libresplit.desktop</launchable>
+  <launchable type="desktop-id">org.libresplit.LibreSplit.desktop</launchable>
   <provides>
     <binary>libresplit</binary>
   </provides>

--- a/meson.build
+++ b/meson.build
@@ -142,7 +142,7 @@ message('buildtype: ' + get_option('buildtype'))
 message('ioctl_maps: ' + ioctl_maps.enabled().to_string())
 
 install_data(
-    'assets/libresplit.desktop',
+    'assets/org.libresplit.LibreSplit.desktop',
     install_dir: get_option('prefix') / get_option('datadir') / 'applications',
 )
 install_data(
@@ -166,7 +166,7 @@ endforeach
 install_data(
     'assets/libresplit.svg',
     install_dir: get_option('prefix') / get_option('datadir') / 'icons/hicolor/scalable/apps/',
-    rename: 'libresplit.png',
+    rename: 'libresplit.svg',
     install_mode: 'rw-r--r--',
 )
 

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -201,8 +201,9 @@ void ls_app_open(GApplication* app,
 LSApp* ls_app_new(void)
 {
     g_set_application_name("LibreSplit");
+    gtk_window_set_default_icon_name("libresplit");
     return g_object_new(LS_APP_TYPE,
-        "application-id", "com.github.wins1ey.libresplit",
+        "application-id", "org.libresplit.LibreSplit",
         "flags", G_APPLICATION_HANDLES_OPEN,
         NULL);
 }


### PR DESCRIPTION
- Standardize app-id across the application.
- Change desktop file to use app-id naming convention.
- Don't rename the svg to png.
  - The meson build was renaming the svg to be a png but this isn't necessary. The svg should be usable as is and we have png fallbacks.

Multiple specs require a standard naming convention for our application that is domain name derived. I.e. for us it should be `org.libresplit` as our domain, and `LibreSplit` is our application. Therefore, `org.libresplit.LibreSplit` and this name should be used for desktop file, app id, rpm metadata etc. See supporting documentation:

- [GTK 3 to 4 migration call out](https://docs.gtk.org/gtk4/migrating-3to4.html#set-a-proper-application-id)
- [Freedesktop desktop entry spec](https://specifications.freedesktop.org/desktop-entry/latest/file-naming.html)
- [GLib valid application id doc](https://docs.gtk.org/gio/type_func.Application.id_is_valid.html)