### PR TITLE
fix(hotkeys): GTK 4 hotkey handling

### DIFF
--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -479,6 +479,7 @@ static void ls_app_window_init(LSAppWindow* win)
     } else {
         LOG_DEBUG("Global Hotkeys Disabled, binding hotkeys only to the main window...");
         GtkEventController* key_controller = gtk_event_controller_key_new();
+        gtk_event_controller_set_propagation_phase(key_controller, GTK_PHASE_CAPTURE);
         g_signal_connect(key_controller, "key-pressed", G_CALLBACK(ls_app_window_keypress), win);
         gtk_widget_add_controller(GTK_WIDGET(win), key_controller);
     }

--- a/src/keybinds/keybinds_callbacks.c
+++ b/src/keybinds/keybinds_callbacks.c
@@ -51,6 +51,16 @@ static int keybind_match(Keybind kb, guint keyval, GdkModifierType state)
     return keyval == kb.key && kb.mods == (state & gtk_accelerator_get_default_mod_mask());
 }
 
+/**
+ * @brief Handles user hotkeys when the window is focussed.
+ *
+ * @param controller The key event controller that received the event.
+ * @param keyval The GDK keyval representing the pressed key.
+ * @param keycode The actual keycode of the pressed key.
+ * @param state The active keyboard modifier flags.
+ * @param data The main LSAppWindow.
+ * @return gboolean Whether or not we handled the keypress event. Returning FALSE allows GTK to continue regular handling propagation.
+ */
 gboolean ls_app_window_keypress(GtkEventControllerKey* controller,
     guint keyval,
     guint keycode,
@@ -72,7 +82,10 @@ gboolean ls_app_window_keypress(GtkEventControllerKey* controller,
         toggle_decorations(win);
     } else if (keybind_match(win->keybinds.toggle_win_on_top, keyval, state)) {
         toggle_win_on_top(win);
+    } else {
+        return FALSE;
     }
+
     return TRUE;
 }
 


### PR DESCRIPTION
Ensures hotkeys propagate to us first before passing it off to GTK to handle.