### PR TITLE
fix: memory leaks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
 
             - name: Install clang-format
               run: |
-                python -m pip install "clang-format=22.1.8"
+                python -m pip install "clang-format==22.1.8"
                 clang-format --version | grep -F "clang-format version 22.1.8"
 
             - name: Format files

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
               uses: actions/checkout@v7
 
             # To install a specific clang-format version
-            - name: Setup Puthon
+            - name: Setup Python
               uses: actions/setup-python@v7
               with:
                 python-version: "3.13"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,17 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v7
 
+            # To install a specific clang-format version
+            - name: Setup Puthon
+              uses: actions/setup-python@v7
+              with:
+                python-version: "3.13"
+
+            - name: Install clang-format
+              run: |
+                python -m pip install "clang-format=22.1.8"
+                clang-format --version | grep -F "clang-format version 22.1.8"
+
             - name: Format files
               run: |
                   clang-format -i $(find src -name '*.c' -or -name '*.h')

--- a/src/gui/actions.c
+++ b/src/gui/actions.c
@@ -304,10 +304,6 @@ void close_activated(GSimpleAction* action,
 static void perform_quit(gpointer window)
 {
     LSAppWindow* win = LS_APP_WINDOW(window);
-    if (win->welcome_box) {
-        welcome_box_destroy(win->welcome_box);
-    }
-
     gtk_window_destroy(GTK_WINDOW(win));
 }
 

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -283,13 +283,13 @@ static void ls_app_window_dispose(GObject* object)
     g_clear_pointer(&win->welcome_box, welcome_box_destroy);
 
     if (win->style != NULL) {
-        gtk_style_context_remove_provider_for_display(win->display, GTK_STYLE_PROVIDER(&win->style));
+        gtk_style_context_remove_provider_for_display(win->display, GTK_STYLE_PROVIDER(win->style));
         g_clear_object(&win->style);
     }
 
     if (win->reset_style != NULL) {
-        gtk_style_context_remove_provider_for_display(win->display, GTK_STYLE_PROVIDER(&win->reset_style));
-        g_clear_object(&win->style);
+        gtk_style_context_remove_provider_for_display(win->display, GTK_STYLE_PROVIDER(win->reset_style));
+        g_clear_object(&win->reset_style);
     }
 
     G_OBJECT_CLASS(ls_app_window_parent_class)->dispose(object);

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -8,6 +8,7 @@
 #include "src/gui/theming.h"
 #include "src/gui/timer.h"
 #include "src/gui/widgets/alert.h"
+#include "src/keybinds/bind.h"
 #include "src/keybinds/keybinds_callbacks.h"
 #include "src/lasr/auto-splitter.h"
 #include "src/logging.h"
@@ -192,8 +193,13 @@ void ls_app_open(GApplication* app,
     }
 
     for (i = 0; i < n_files; i++) {
-        ls_app_window_open(win, g_file_get_path(files[i]));
+        gchar* path = g_file_get_path(files[i]);
+        if (path != NULL) {
+            ls_app_window_open(win, path);
+            g_free(path);
+        }
     }
+
     gtk_window_present(GTK_WINDOW(win));
 }
 
@@ -256,8 +262,35 @@ static void ls_component_destroy(gpointer data)
 static void ls_app_window_dispose(GObject* object)
 {
     LSAppWindow* win = LS_APP_WINDOW(object);
+
+    if (win->step_source_id != 0) {
+        g_source_remove(win->step_source_id);
+        win->step_source_id = 0;
+    }
+
+    if (win->draw_source_id) {
+        g_source_remove(win->draw_source_id);
+        win->draw_source_id = 0;
+    }
+
+    if (win->global_hotkeys_initialized) {
+        keybinder_dispose();
+        win->global_hotkeys_initialized = false;
+    }
+
     GList* components = g_steal_pointer(&win->components);
     g_list_free_full(components, ls_component_destroy);
+    g_clear_pointer(&win->welcome_box, welcome_box_destroy);
+
+    if (win->style != NULL) {
+        gtk_style_context_remove_provider_for_display(win->display, GTK_STYLE_PROVIDER(&win->style));
+        g_clear_object(&win->style);
+    }
+
+    if (win->reset_style != NULL) {
+        gtk_style_context_remove_provider_for_display(win->display, GTK_STYLE_PROVIDER(&win->reset_style));
+        g_clear_object(&win->style);
+    }
 
     G_OBJECT_CLASS(ls_app_window_parent_class)->dispose(object);
 }
@@ -457,7 +490,11 @@ static void ls_app_window_init(LSAppWindow* win)
     int i;
 
     win->display = gdk_display_get_default();
+    win->reset_style = NULL;
     win->style = NULL;
+    win->step_source_id = 0;
+    win->draw_source_id = 0;
+    win->global_hotkeys_initialized = false;
     win->context_menu = NULL;
     win->resize_cursor_hover = false;
 
@@ -505,6 +542,7 @@ static void ls_app_window_init(LSAppWindow* win)
     if (win->opts.global_hotkeys && (is_x11_display() || force_global_hotkeys)) {
         LOG_DEBUG("Global Hotkeys Enabled, binding hotkeys globally...");
         bind_global_hotkeys(cfg, win);
+        win->global_hotkeys_initialized = true;
     } else {
         LOG_DEBUG("Global Hotkeys Disabled, binding hotkeys only to the main window...");
         GtkEventController* key_controller = gtk_event_controller_key_new();
@@ -566,7 +604,7 @@ static void ls_app_window_init(LSAppWindow* win)
 
     LOG_DEBUG("Setting up timers for updating and drawing the window...");
     // Update the internal state every millisecond
-    g_timeout_add(1, ls_app_window_step, win);
+    win->step_source_id = g_timeout_add(1, ls_app_window_step, win);
     // Draw the window at 30 FPS
-    g_timeout_add((int)(1000 / 30.), ls_app_window_draw, win);
+    win->draw_source_id = g_timeout_add((int)(1000 / 30.), ls_app_window_draw, win);
 }

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -234,8 +234,37 @@ static void ls_app_window_size_allocate(GtkWidget* widget, int width, int height
     }
 }
 
+/**
+ * @brief Call the component's delete method when the window is being disposed.
+ *
+ * @param data The component to cleanup.
+ */
+static void ls_component_destroy(gpointer data)
+{
+    LSComponent* component = data;
+    if (component && component->ops && component->ops->delete) {
+        component->ops->delete(component);
+    }
+}
+
+/**
+ * @brief Dispose handler for the main window. This happens when the object
+ * is being released and resources should be released as well.
+ *
+ * @param object The main window object.
+ */
+static void ls_app_window_dispose(GObject* object)
+{
+    LSAppWindow* win = LS_APP_WINDOW(object);
+    GList* components = g_steal_pointer(&win->components);
+    g_list_free_full(components, ls_component_destroy);
+
+    G_OBJECT_CLASS(ls_app_window_parent_class)->dispose(object);
+}
+
 static void ls_app_window_class_init(LSAppWindowClass* class)
 {
+    G_OBJECT_CLASS(class)->dispose = ls_app_window_dispose;
     GTK_WIDGET_CLASS(class)->size_allocate = ls_app_window_size_allocate;
 }
 

--- a/src/gui/app_window.h
+++ b/src/gui/app_window.h
@@ -52,6 +52,9 @@ typedef struct _LSAppWindow {
     GtkWidget* footer;
     GtkCssProvider* reset_style; /*!< The "reset rules" provider, will remove desktop theme rules */
     GtkCssProvider* style; /*!< Current style provider, there can be only one */
+    guint step_source_id; /*!< Source ID for the run clock callback */
+    guint draw_source_id; /*!< Source ID for the gui draw callback */
+    bool global_hotkeys_initialized; /*!< Whether global hotkeys have been binded */
     LSKeybinds keybinds; /*!< The keybinds related to this application window */
     LSOpts opts; /*!< The window options */
 } LSAppWindow;

--- a/src/gui/component/splits.c
+++ b/src/gui/component/splits.c
@@ -33,21 +33,19 @@ extern LSComponentOps ls_splits_operations;
 void free_all(LSSplits* self_)
 {
     LSSplits* self = (LSSplits*)self_;
-    if (self->split_rows) {
-        free(self->split_rows);
-    }
-    if (self->split_titles) {
-        free(self->split_titles);
-    }
-    if (self->split_icons) {
-        free(self->split_icons);
-    }
-    if (self->split_deltas) {
-        free(self->split_deltas);
-    }
-    if (self->split_times) {
-        free(self->split_times);
-    }
+
+    free(self->split_rows);
+    free(self->split_titles);
+    free(self->split_icons);
+    free(self->split_deltas);
+    free(self->split_times);
+
+    self->split_rows = NULL;
+    self->split_titles = NULL;
+    self->split_icons = NULL;
+    self->split_deltas = NULL;
+    self->split_times = NULL;
+    self->split_count = 0;
 }
 
 /**
@@ -56,11 +54,11 @@ void free_all(LSSplits* self_)
 LSComponent* ls_component_splits_new(void)
 {
     LSSplits* self;
-
-    self = malloc(sizeof(LSSplits));
+    self = calloc(1, sizeof(LSSplits));
     if (!self) {
         return NULL;
     }
+
     self->base.ops = &ls_splits_operations;
 
     self->split_adjust = gtk_adjustment_new(0., 0., 0., 0., 0., 0.);
@@ -101,6 +99,13 @@ static void splits_delete(LSComponent* self)
 {
     LSSplits* splits = (LSSplits*)self;
     g_clear_signal_handler(&splits->scroll_changed_handler, splits->split_adjust);
+    free_all(splits);
+    if (splits->icons_css_provider) {
+        gtk_style_context_remove_provider_for_display(
+            gtk_widget_get_display(splits->container),
+            GTK_STYLE_PROVIDER(splits->icons_css_provider));
+        g_clear_object(&splits->icons_css_provider);
+    }
     free(self);
 }
 

--- a/src/gui/component/splits.c
+++ b/src/gui/component/splits.c
@@ -228,30 +228,25 @@ static void splits_show_game(LSComponent* self_, const ls_game* game,
         gtk_widget_set_halign(self->split_titles[i], GTK_ALIGN_START);
         gtk_widget_set_hexpand(self->split_titles[i], TRUE);
 
-        if (game->split_titles[i]
-            && strlen(game->split_titles[i])) {
-            char* c = &str[12];
-            strcpy(str, "split-title-");
-            strcpy(c, game->split_titles[i]);
+        gchar* split_title_class = NULL;
+        if (game->split_titles[i] && game->split_titles[i][0] != '\0') {
+            split_title_class = g_strdup_printf("split-title-%s", game->split_titles[i]);
+            gchar* c = split_title_class + strlen("split-title-");
+
             do {
-                if (!isalnum(*c)) {
-                    *c = '-';
-                } else {
-                    *c = tolower(*c);
-                }
+                *c = g_ascii_isalnum(*c) ? g_ascii_tolower(*c) : '-';
             } while (*++c != '\0');
-            {
-                add_class(self->split_rows[i], str);
-            }
+
+            add_class(self->split_rows[i], split_title_class);
         }
 
         if (game->contains_icons) {
-            if (game->split_icon_paths[i]) {
+            if (game->split_icon_paths[i] && split_title_class) {
                 // g_string_append_printf(icons_css_src, ".split:nth-child(%d) .split-icon { background-image: url('%s'); }", i+1, game->split_icon_paths[i]);
                 g_string_append_printf(
                     icons_css_src,
                     ".%s .split-icon { background-image: url('%s'); }",
-                    str, game->split_icon_paths[i]);
+                    split_title_class, game->split_icon_paths[i]);
             }
             self->split_icons[i] = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
             add_class(self->split_icons[i], "split-icon");
@@ -259,6 +254,8 @@ static void splits_show_game(LSComponent* self_, const ls_game* game,
             gtk_widget_set_size_request(self->split_icons[i], 20, 20);
             gtk_box_append(GTK_BOX(self->split_rows[i]), self->split_icons[i]);
         }
+
+        g_free(split_title_class);
         gtk_box_append(GTK_BOX(self->split_rows[i]), self->split_titles[i]);
 
         self->split_deltas[i] = gtk_label_new(NULL);

--- a/src/gui/component/splits.c
+++ b/src/gui/component/splits.c
@@ -187,8 +187,12 @@ static void splits_show_game(LSComponent* self_, const ls_game* game,
     self->split_count = game->split_count;
 
     self->split_rows = calloc(self->split_count, sizeof(GtkWidget*));
-    if (!self->split_rows)
+    if (!self->split_rows) {
+        // nothing has been allocated but call free_all
+        // for consistency and to set split_count back to 0
+        free_all(self);
         return;
+    }
 
     self->split_titles = calloc(self->split_count, sizeof(GtkWidget*));
     if (!self->split_titles) {

--- a/src/gui/widgets/settings_dialog.c
+++ b/src/gui/widgets/settings_dialog.c
@@ -160,6 +160,11 @@ static void save_gui_settings(GtkButton* button, gpointer app)
             case CFG_KEYBIND:
                 {
                     const char* str_value = gtk_entry_buffer_get_text(setting_to_save.entry_buffer);
+                    if (strlen(str_value) >= sizeof(setting_to_save.settings_entry->value.s)) {
+                        LOG_WARNF("%s was longer than the max size %zu", str_value, sizeof(setting_to_save.settings_entry->value.s));
+                        break;
+                    }
+
                     strcpy(setting_to_save.settings_entry->value.s, str_value);
                     break;
                 }
@@ -308,7 +313,7 @@ static gboolean build_settings_dialog(gpointer data)
                         GtkWidget* lbl_kb = new_setting_label(entry.desc);
                         gtk_grid_attach(GTK_GRID(grid), lbl_kb, 0, row, 1, 1);
 
-                        gui_settings[settings_idx].entry_buffer = gtk_entry_buffer_new(entry.value.s, sizeof(entry.value.s));
+                        gui_settings[settings_idx].entry_buffer = gtk_entry_buffer_new(entry.value.s, -1);
                         gui_settings[settings_idx].widget = gtk_entry_new_with_buffer(gui_settings[settings_idx].entry_buffer);
                         gtk_entry_set_icon_from_icon_name(GTK_ENTRY(gui_settings[settings_idx].widget), GTK_ENTRY_ICON_SECONDARY, "edit-clear");
                         GtkEventController* key_controller = gtk_event_controller_key_new();
@@ -335,7 +340,7 @@ static gboolean build_settings_dialog(gpointer data)
                         char setting_as_str[64];
                         sprintf(setting_as_str, "%d", entry.value.i);
 
-                        gui_settings[settings_idx].entry_buffer = gtk_entry_buffer_new(setting_as_str, sizeof(setting_as_str));
+                        gui_settings[settings_idx].entry_buffer = gtk_entry_buffer_new(setting_as_str, -1);
                         gui_settings[settings_idx].widget = gtk_entry_new_with_buffer(gui_settings[settings_idx].entry_buffer);
                         gtk_widget_set_hexpand(gui_settings[settings_idx].widget, TRUE);
                         gtk_grid_attach(GTK_GRID(grid), gui_settings[settings_idx].widget, 1, row, 1, 1);

--- a/src/gui/widgets/settings_dialog.c
+++ b/src/gui/widgets/settings_dialog.c
@@ -299,8 +299,9 @@ static gboolean build_settings_dialog(gpointer data)
                         GtkWidget* lbl_str = new_setting_label(entry.desc);
                         gtk_grid_attach(GTK_GRID(grid), lbl_str, 0, row, 1, 1);
 
-                        gui_settings[settings_idx].entry_buffer = gtk_entry_buffer_new(entry.value.s, sizeof(entry.value.s));
+                        gui_settings[settings_idx].entry_buffer = gtk_entry_buffer_new(entry.value.s, -1);
                         gui_settings[settings_idx].widget = gtk_entry_new_with_buffer(gui_settings[settings_idx].entry_buffer);
+                        g_object_unref(gui_settings[settings_idx].entry_buffer);
                         gtk_entry_set_icon_from_icon_name(GTK_ENTRY(gui_settings[settings_idx].widget), GTK_ENTRY_ICON_SECONDARY, "edit-clear");
                         g_signal_connect(gui_settings[settings_idx].widget, "icon-press", G_CALLBACK(on_entry_clear_press), NULL);
                         gtk_widget_set_hexpand(gui_settings[settings_idx].widget, TRUE);
@@ -315,6 +316,7 @@ static gboolean build_settings_dialog(gpointer data)
 
                         gui_settings[settings_idx].entry_buffer = gtk_entry_buffer_new(entry.value.s, -1);
                         gui_settings[settings_idx].widget = gtk_entry_new_with_buffer(gui_settings[settings_idx].entry_buffer);
+                        g_object_unref(gui_settings[settings_idx].entry_buffer);
                         gtk_entry_set_icon_from_icon_name(GTK_ENTRY(gui_settings[settings_idx].widget), GTK_ENTRY_ICON_SECONDARY, "edit-clear");
                         GtkEventController* key_controller = gtk_event_controller_key_new();
                         gtk_event_controller_set_propagation_phase(key_controller, GTK_PHASE_CAPTURE);
@@ -342,6 +344,7 @@ static gboolean build_settings_dialog(gpointer data)
 
                         gui_settings[settings_idx].entry_buffer = gtk_entry_buffer_new(setting_as_str, -1);
                         gui_settings[settings_idx].widget = gtk_entry_new_with_buffer(gui_settings[settings_idx].entry_buffer);
+                        g_object_unref(gui_settings[settings_idx].entry_buffer);
                         gtk_widget_set_hexpand(gui_settings[settings_idx].widget, TRUE);
                         gtk_grid_attach(GTK_GRID(grid), gui_settings[settings_idx].widget, 1, row, 1, 1);
                         break;

--- a/src/keybinds/bind.c
+++ b/src/keybinds/bind.c
@@ -628,7 +628,7 @@ void keybinder_dispose(void)
         xevent_handler_id = 0;
     }
 
-    GList* old_bindings = g_steal_pointer(&bindings);
+    GSList* old_bindings = g_steal_pointer(&bindings);
     for (GSList* iter = old_bindings; iter != NULL; iter = iter->next) {
         struct Binding* binding = iter->data;
         do_ungrab_key(binding);
@@ -640,7 +640,7 @@ void keybinder_dispose(void)
         g_free(binding);
     }
 
-    g_list_free(old_bindings);
+    g_slist_free(old_bindings);
     g_clear_object(&keybinder_display);
     processing_event = FALSE;
     last_event_time = 0;

--- a/src/keybinds/bind.c
+++ b/src/keybinds/bind.c
@@ -76,6 +76,8 @@ static guint32 last_event_time = 0;
 static gboolean processing_event = FALSE;
 static GdkModifierType modmap[8];
 static int xkb_event_type = 0;
+static GdkDisplay* keybinder_display = NULL;
+static gulong xevent_handler_id = 0;
 
 /* Build a map from X11's real modifier slots to the corresponding
  * Meta, Super, and Hyper modifiers. This replaces the modifier map
@@ -309,8 +311,8 @@ grab_ungrab(Window rootwin,
     gboolean grab)
 {
     int k;
-    GdkKeymapKey* keys;
-    gint n_keys;
+    GdkKeymapKey* keys = NULL;
+    gint n_keys = 0;
     GdkModifierType add_modifiers;
     XkbDescPtr xmap;
     gboolean success = FALSE;
@@ -321,10 +323,15 @@ grab_ungrab(Window rootwin,
         XkbAllClientInfoMask,
         XkbUseCoreKbd);
 
-    gdk_display_map_keyval(display, keyval, &keys, &n_keys);
-
-    if (n_keys == 0)
+    if (xmap == NULL) {
         return FALSE;
+    }
+
+    if (!gdk_display_map_keyval(display, keyval, &keys, &n_keys) || n_keys == 0) {
+        g_free(keys);
+        XkbFreeKeyboard(xmap, XkbAllComponentsMask, TRUE);
+        return FALSE;
+    }
 
     for (k = 0; k < n_keys; k++) {
         /* NOTE: We only bind for the first group,
@@ -361,7 +368,7 @@ grab_ungrab(Window rootwin,
         }
     }
     g_free(keys);
-    XkbFreeClientMap(xmap, 0, TRUE);
+    XkbFreeKeyboard(xmap, XkbAllComponentsMask, TRUE);
 
     return success;
 }
@@ -503,9 +510,14 @@ filter_func(GdkDisplay* display, gpointer gdk_xevent, gpointer data)
             add_virtual_modifiers(&modifiers);
             modifiers &= mod_mask;
 
-            TRACE(g_print("Translated keyval: %u, vmodifiers: 0x%x, name: %s\n",
-                keyval, modifiers,
-                gtk_accelerator_name(keyval, modifiers)));
+#ifdef DEBUG
+            {
+                gchar* accelerator = gtk_accelerator_name(keyval, modifiers);
+                TRACE(g_print("Translated keyval: %u, vmodifiers: 0x%x, name: %s\n",
+                    keyval, modifiers, accelerator));
+                g_free(accelerator);
+            }
+#endif
 
             /*
              * Set the last event time for use when showing
@@ -580,6 +592,10 @@ keymap_changed(Display* xdisplay)
 void keybinder_init(void)
 {
     GdkDisplay* display = gdk_display_get_default();
+    if (keybinder_display != NULL || display == NULL) {
+        return;
+    }
+
     Display* xdisplay = gdk_x11_display_get_xdisplay(display);
     Window rootwin = gdk_x11_display_get_xrootwindow(display);
     int xkb_opcode;
@@ -595,10 +611,40 @@ void keybinder_init(void)
         &xkb_minor);
     update_modmap(xdisplay);
 
-    g_signal_connect_after(display,
+    keybinder_display = g_object_ref(display);
+    xevent_handler_id = g_signal_connect_after(display,
         "xevent",
         G_CALLBACK(filter_func),
         GDK_XID_TO_POINTER(rootwin));
+}
+
+/**
+ * @brief Release global key grabs and disconnect X11 event handler.
+ */
+void keybinder_dispose(void)
+{
+    if (keybinder_display != NULL && xevent_handler_id != 0) {
+        g_signal_handler_disconnect(keybinder_display, xevent_handler_id);
+        xevent_handler_id = 0;
+    }
+
+    GList* old_bindings = g_steal_pointer(&bindings);
+    for (GSList* iter = old_bindings; iter != NULL; iter = iter->next) {
+        struct Binding* binding = iter->data;
+        do_ungrab_key(binding);
+        if (binding->notify) {
+            binding->notify(binding->user_data);
+        }
+
+        g_free(binding->keystring);
+        g_free(binding);
+    }
+
+    g_list_free(old_bindings);
+    g_clear_object(&keybinder_display);
+    processing_event = FALSE;
+    last_event_time = 0;
+    xkb_event_type = 0;
 }
 
 /**

--- a/src/keybinds/bind.h
+++ b/src/keybinds/bind.h
@@ -31,6 +31,7 @@ G_BEGIN_DECLS
 typedef void (*KeybinderHandler)(const char* keystring, void* user_data);
 
 void keybinder_init(void);
+void keybinder_dispose(void);
 
 gboolean keybinder_bind(const char* keystring,
     KeybinderHandler handler,

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -541,6 +541,7 @@ void run_auto_splitter(void)
         fprintf(stderr, "Lua syntax error: %s\n", error_msg);
         lua_pop(L, 1); // Remove the error message from the stack
         lua_close(L);
+        maps_clearCache();
         atomic_store(&auto_splitter_enabled, false);
         return;
     }
@@ -556,6 +557,7 @@ void run_auto_splitter(void)
         }
         lua_pop(L, 1);
         lua_close(L);
+        maps_clearCache();
         atomic_store(&auto_splitter_enabled, false);
         return;
     }
@@ -654,4 +656,5 @@ void run_auto_splitter(void)
     }
 
     lua_close(L);
+    maps_clearCache();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -123,11 +123,12 @@ int main(int argc, char* argv[])
     pthread_t t3; // Logging Thread
     pthread_create(&t3, NULL, &loggingThread, NULL);
 
-    g_application_run(G_APPLICATION(g_app), argc, argv);
+    int status = g_application_run(G_APPLICATION(g_app), argc, argv);
 
     pthread_join(t1, NULL);
     pthread_join(t2, NULL);
     pthread_join(t3, NULL);
 
-    return 0;
+    g_clear_object(&g_app);
+    return status;
 }

--- a/src/timer.c
+++ b/src/timer.c
@@ -367,7 +367,14 @@ void ls_game_release(ls_game* game)
         game->split_times = 0;
     }
     if (game->split_icon_paths) {
+        for (unsigned int i = 0; i < game->split_count; ++i) {
+            if (game->split_icon_paths[i]) {
+                free(game->split_icon_paths[i]);
+                game->split_icon_paths[i] = 0;
+            }
+        }
         free(game->split_icon_paths);
+        game->split_icon_paths = 0;
     }
     if (game->segment_times) {
         free(game->segment_times);

--- a/src/timer.c
+++ b/src/timer.c
@@ -56,13 +56,20 @@ inline ls_time ls_timer_get_time(const ls_timer* timer, bool load_removed)
  */
 long long ls_time_value(const char* string)
 {
-    char seconds_part[256];
+    if (!string) {
+        return 0;
+    }
+
+    char seconds_part[MAX_TIMESTAMP_LENGTH];
     double subseconds_part = 0.;
     int hours = 0;
     int minutes = 0;
     int seconds = 0;
     int sign = 1;
-    if (!string || !strlen(string)) {
+    unsigned int time_str_len = strlen(string);
+
+    // It's unreasonable for a time string to be larger than this.
+    if (!time_str_len || time_str_len >= MAX_TIMESTAMP_LENGTH) {
         return 0;
     }
 
@@ -804,10 +811,15 @@ int ls_game_save(const ls_game* game)
     }
     const int json_dump_result = json_dump_file(json, game->path, JSON_PRESERVE_ORDER | JSON_INDENT(2));
     if (json_dump_result) {
-        LOG_WARNF("Error dumping JSON:\n%s", json_dumps(json, JSON_PRESERVE_ORDER | JSON_INDENT(2)));
+        char* json_dump = json_dumps(json, JSON_PRESERVE_ORDER | JSON_INDENT(2));
+        LOG_WARNF("Error dumping JSON:\n%s", json_dump != NULL ? json_dump : "");
         LOG_WARNF("Error: '%d'", json_dump_result);
         LOG_WARNF("Path: %s", game->path);
         error = 1;
+
+        if (json_dump != NULL) {
+            free(json_dump);
+        }
     }
     json_decref(json);
     return error;
@@ -896,15 +908,21 @@ int ls_run_save(ls_timer* timer, const char* reason)
     int ret = snprintf(filename, sizeof(filename), "%s/run_%s.json", path, time_buf);
     if (ret < 0 || (size_t)ret >= sizeof(filename)) {
         LOG_WARN("Error creating run filename. The path may be too long, aborting save.");
+        json_decref(json);
         return 1;
     }
 
     const int json_dump_result = json_dump_file(json, filename, JSON_PRESERVE_ORDER | JSON_INDENT(2));
     if (json_dump_result) {
-        LOG_WARNF("Error dumping JSON:\n%s", json_dumps(json, JSON_PRESERVE_ORDER | JSON_INDENT(2)));
+        char* json_dump = json_dumps(json, JSON_PRESERVE_ORDER | JSON_INDENT(2));
+        LOG_WARNF("Error dumping JSON:\n%s", json_dump != NULL ? json_dump : "");
         LOG_WARNF("Error: '%d'", json_dump_result);
         LOG_WARNF("Path: %s", filename);
         error = 1;
+
+        if (json_dump != NULL) {
+            free(json_dump);
+        }
     }
 
     json_decref(json);

--- a/src/timer.c
+++ b/src/timer.c
@@ -66,7 +66,7 @@ long long ls_time_value(const char* string)
     int minutes = 0;
     int seconds = 0;
     int sign = 1;
-    unsigned int time_str_len = strlen(string);
+    size_t time_str_len = strlen(string);
 
     // It's unreasonable for a time string to be larger than this.
     if (!time_str_len || time_str_len >= MAX_TIMESTAMP_LENGTH) {

--- a/src/timer.h
+++ b/src/timer.h
@@ -10,6 +10,8 @@
 #define LS_INFO_BEST_SPLIT (1 << 2)
 #define LS_INFO_BEST_SEGMENT (1 << 3) // Gold split
 
+#define MAX_TIMESTAMP_LENGTH 256
+
 extern AppConfig cfg;
 
 /**


### PR DESCRIPTION
These are mostly pre-existing, not related to GTK 4 migration, but fixing them forward on the GTK 4 branch will make merging easier for now. I'm going to go through and list each fix one by one here so it makes sense on review, in the order I found and fixed stuff.

1. in timer.c when you load splits, if there's an icon each split_icon_paths entry is an strdup, so we need to free each entry, not just the array.
2. in timer.c I also added some defensive checks to make sure the timestamp string is within our expected buffer's size.
3. in timer.c json_dumps returns a new string that must be free'd after usage. So free the results in the areas that we use json_dumps.
4. in timer.c during splits saving, if we early return due to an error we were leaking the root json object.
5. add a dispose handler for the main window class in app_window.c
  a. We need this so that we can clean up memory before destroying everything that we still own.
  b. This allows us to call the delete functions for each component.
  c. This allows us to fix point 7 coming up.
6. Clean up some of the splits component's memory management and make sure to free up all the stuff we allocated on delete.
7. When the window is closed, we were not clearing our 2 `g_timeout_add` calls for our ls step and ls draw tick functions. This means they both still happen after the window is disposed and can lead to use-after-free issues on `win` (fixed by keeping track of their `g_timeout_add` ids so we can clear them on dispose and prevent the next calls.
8. Similar to point 7 above, if we initialize global hotkeys, we should shut it down and clear all the x11 keybind stuff. See bind.c dispose function.
  a. [XkbGetMap](https://manpages.debian.org/jessie/libx11-doc/XkbGetMap.3.en.html) - Allocate an XkbDescRec structure and populate it with the server's keyboard client map and server map. This means `XkbFreeClientMap` isn't enough to free the resources we allocate here. [XkbFreeKeyboard](https://xorg.freedesktop.org/archive/X11R7.5/doc/man/man3/XkbFreeKeyboard.3.html) is appropriate for freeing XkbDescRec struct apparently.
  b. the n_keys early return had no free so it leaks.
  c. gdk_display_map_keyval can return false if nothing is found and should be handled.
9. In settings_dialog.c while the strcpy to a fixed buffer of length 4096 should be more than enough based on the kinds of settings we have, gtk_entry_buffer_get_text technically can return a bigger strings than our 4096 string setting buffer, so just reject those defensively.
10. In settings_dialog.c gtk_entry_buffer_new should use -1 on the size for null terminated strings.
  a. Once we're done with the new entry buffers we need to release them.
11. actions.c and app_window.c don't destroy the welcome_box in the action box action, handle it in window disposal instead. (handle X button and other methods of closing, not just context menu)
12. A couple of spots missing `maps_clearCache` in LASR. @EXtremeExploit @Penaz91 please double check on this to make sure this is correct :thinking: 
13. splits.c while loading the title, we use str as a buffer for the title class and the title itself. str is a 256 length string which is fine, realistically a title should never be longer than like 20? characters? But still prevent malicious splits files or any other shenanigans by using a gchar string dynamically allocated with g_strdup_printf so that string can be whatever size it needs to be. This way the worst that can happen is just libresplit looks weird but the user is safe.

I was getting clang-format reject my changes in CI but accept them on my machine. Looks like Ubuntu 24 uses clang-format v18 so probably some outdated rules there in the defaults. I changed the CI job to use a newer version.