### PR TITLE
fix(icons): handle local file paths for icons

### DIFF
--- a/docs/split-files.md
+++ b/docs/split-files.md
@@ -42,7 +42,8 @@ Most of the above keys are optional.
 
 A time object is an object containing times for real time and game time. Times in a time object are strings in `HH:MM:SS.mmmmmm` format.
 
-Icons can be either a local file path (preferably absolute) or a URL. Note that only GTK-supported image formats will work. For example, `.svg` and `.webp` won't.
+Icons can be either a local file path (preferably absolute) or a URL. Note that only GTK-supported image formats will work.
+Most common immage formats like PNG and JPEG should work. Exact format support may vary by system.
 
 ## Example
 

--- a/docs/split-files.md
+++ b/docs/split-files.md
@@ -43,7 +43,7 @@ Most of the above keys are optional.
 A time object is an object containing times for real time and game time. Times in a time object are strings in `HH:MM:SS.mmmmmm` format.
 
 Icons can be either a local file path (preferably absolute) or a URL. Note that only GTK-supported image formats will work.
-Most common immage formats like PNG and JPEG should work. Exact format support may vary by system.
+Most common image formats like PNG and JPEG should work. Exact format support may vary by system.
 
 ## Example
 

--- a/src/gui/component/splits.c
+++ b/src/gui/component/splits.c
@@ -51,6 +51,93 @@ void free_all(LSSplits* self_)
 }
 
 /**
+ * @brief Resolves the icon file path to a URI.
+ * This handles converting full/relative file paths to the user's system
+ * so that it can be converted to a usable file:// URI
+ * while retaining already valid URI's for web urls, data-urls etc.
+ *
+ * If you use this, you must g_free the result if it is not NULL after usage.
+ *
+ * @param game The game struct for the current splits file.
+ * @param source The path to the icon being loaded.
+ * @return char* A new string to for the valid icon URI.
+ */
+static char* split_icon_uri(const ls_game* game, const char* source)
+{
+    // max_len should be -1 for null terminated strings.
+    if (!source || !g_utf8_validate(source, -1, NULL)) {
+        return NULL;
+    }
+
+    // The supplied source is already correctly formatted.
+    // Duplicate it so the followup free doesn't kill the source path.
+    if (g_uri_peek_scheme(source)) {
+        return g_strdup(source);
+    }
+
+    GFile* icon;
+    if (g_path_is_absolute(source)) {
+        icon = g_file_new_for_path(source);
+    } else {
+        GFile* splits_file = g_file_new_for_path(game->path);
+        GFile* parent_dir = g_file_get_parent(splits_file);
+        g_object_unref(splits_file);
+
+        if (!parent_dir) {
+            return NULL;
+        }
+
+        icon = g_file_resolve_relative_path(parent_dir, source);
+        g_object_unref(parent_dir);
+    }
+
+    char* uri = g_file_get_uri(icon);
+    g_object_unref(icon);
+    return uri;
+}
+
+/**
+ * @brief Appends a URI to a GString. Wraps the string in quotes and then escapes
+ * special characters to w3 spec so that non-basic URIs don't break.
+ * This also applies quotes so that you can pass something like
+ * https://url.com
+ * and get
+ * "https://url.com"
+ * As your response to pass directly to a css URL such as
+ * background-image: url(YOUR-STRING);
+ *
+ * @param str The string to append the URI to.
+ * @param value A raw URI path string.
+ */
+static void append_quoted_uri(GString* str, const char* value)
+{
+    g_string_append_c(str, '"');
+
+    // https://www.w3.org/TR/cssom-1/#serialize-a-string
+    for (const unsigned char* c = (const unsigned char*)value; *c != '\0'; ++c) {
+        switch (*c) {
+            /** U+0022 = " */
+            case '"':
+                g_string_append(str, "\\\"");
+                break;
+            /** U+005C = \ */
+            case '\\':
+                g_string_append(str, "\\\\");
+                break;
+            /** NULL character means the end of string so we don't need to handle that */
+            default:
+                if ((*c >= 1 && *c <= 0x1F) || *c == 0x7F) {
+                    g_string_append_printf(str, "\\%x ", *c);
+                } else {
+                    g_string_append_c(str, *c);
+                }
+        }
+    }
+
+    g_string_append_c(str, '"');
+}
+
+/**
  * Constructor
  */
 LSComponent* ls_component_splits_new(void)
@@ -242,11 +329,13 @@ static void splits_show_game(LSComponent* self_, const ls_game* game,
 
         if (game->contains_icons) {
             if (game->split_icon_paths[i]) {
-                // g_string_append_printf(icons_css_src, ".split:nth-child(%d) .split-icon { background-image: url('%s'); }", i+1, game->split_icon_paths[i]);
-                g_string_append_printf(
-                    icons_css_src,
-                    ".%s .split-icon { background-image: url('%s'); }",
-                    str, game->split_icon_paths[i]);
+                char* icon = split_icon_uri(game, game->split_icon_paths[i]);
+                if (icon) {
+                    g_string_append_printf(icons_css_src, ".%s .split-icon { background-image: url(", str);
+                    append_quoted_uri(icons_css_src, icon);
+                    g_string_append(icons_css_src, "); }");
+                    g_free(icon);
+                }
             }
             self->split_icons[i] = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
             add_class(self->split_icons[i], "split-icon");


### PR DESCRIPTION
This converts local file paths to valid file:// URIs so that we can maintain compatibility with existing splits files and continue using absolute/relative file paths to icons. This still maintains compatibility with other URI types such as web urls and data-urls.

This also adds proper uri escaping. I used this doc to replace characters with their escaped counterparts to prevent URLs from breaking:
https://www.w3.org/TR/cssom-1/#serialize-a-string

These are local icons with absolute file paths:
<img width="663" height="948" alt="image" src="https://github.com/user-attachments/assets/460be701-64e7-48f8-ba21-63288380eba3" />

These are web icons, the first uses a web URL to an SVG showcasing that SVGs are supported so long as your system dependencies have the correct GdkPixbufs installed (which most should)
and the second uses a data-url for a base64 encoded image directly in the splits file:
<img width="741" height="1136" alt="image" src="https://github.com/user-attachments/assets/2d7b30e3-beac-4504-b434-d1ce21965b42" />
