### PR TITLE
feat(saves): handle game saving atomically

### DIFF
--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -348,6 +348,7 @@ void ls_app_window_destroy(GtkWidget* widget, gpointer data)
 {
     LOG_INFO("Exiting LibreSplit. GG!");
     LSAppWindow* win = (LSAppWindow*)widget;
+    save_game_join();
     if (win->timer) {
         ls_timer_release(win->timer);
         win->timer = 0;

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -7,6 +7,136 @@
 
 extern AppConfig cfg;
 
+static GThread* save_thread;
+static atomic_bool saving;
+
+/**
+ * @brief Duplicates the ls_game as snapshot. This is useful
+ * to allow for asynchronous game saves to perform the save operation
+ * without worry that the ls_game struct might change in the middle
+ * of the operation.
+ *
+ * @param game The ls_game struct to duplicate
+ * @return ls_game* A pointer to the snapshot - must be independently ls_game_release'd when done with it
+ */
+static ls_game* create_snapshot(const ls_game* game)
+{
+    ls_game* snapshot = calloc(1, sizeof(ls_game));
+    if (!snapshot) {
+        LOG_ERR("snapshot creation: unable to allocate memory for `ls_game`")
+        return NULL;
+    }
+
+    memcpy(snapshot->path, game->path, sizeof(game->path));
+    snapshot->comparison_method = game->comparison_method;
+    snapshot->attempt_count = game->attempt_count;
+    snapshot->finished_count = game->finished_count;
+    snapshot->width = game->width;
+    snapshot->height = game->height;
+    snapshot->world_record = game->world_record;
+    snapshot->start_delay = game->start_delay;
+    snapshot->contains_icons = game->contains_icons;
+    snapshot->split_count = game->split_count;
+
+    if (game->title) {
+        snapshot->title = strdup(game->title);
+        if (!snapshot->title) {
+            LOG_ERR("snapshot creation: unable to duplicate `title` in memory");
+            goto snapshot_failed;
+        }
+    }
+
+    if (game->theme) {
+        snapshot->theme = strdup(game->theme);
+        if (!snapshot->theme) {
+            LOG_ERR("snapshot creation: unable to duplicate `theme` in memory");
+            goto snapshot_failed;
+        }
+    }
+
+    if (game->theme_variant) {
+        snapshot->theme_variant = strdup(game->theme_variant);
+        if (!snapshot->theme_variant) {
+            LOG_ERR("snapshot creation: unable to duplicate `theme_variant` in memory");
+            goto snapshot_failed;
+        }
+    }
+
+    if (!game->split_count) {
+        return snapshot;
+    }
+
+    if (!game->split_titles || !game->split_icon_paths || !game->split_times || !game->segment_times || !game->best_splits || !game->best_segments) {
+        LOG_ERR("snapshot creation: positive split_count with empty split array(s)");
+        goto snapshot_failed;
+    }
+
+    snapshot->split_titles = calloc(game->split_count, sizeof(char*));
+    if (!snapshot->split_titles) {
+        LOG_ERR("snapshot creation: unable to allocate memory for `split_titles`");
+        goto snapshot_failed;
+    }
+
+    snapshot->split_icon_paths = calloc(game->split_count, sizeof(char*));
+    if (!snapshot->split_icon_paths) {
+        LOG_ERR("snapshot creation: unable to allocate memory for `split_icon_paths`");
+        goto snapshot_failed;
+    }
+
+    snapshot->split_times = calloc(game->split_count, sizeof(ls_time));
+    if (!snapshot->split_times) {
+        LOG_ERR("snapshot creation: unable to allocate memory for `split_times`");
+        goto snapshot_failed;
+    }
+
+    snapshot->segment_times = calloc(game->split_count, sizeof(ls_time));
+    if (!snapshot->segment_times) {
+        LOG_ERR("snapshot creation: unable to allocate memory for `segment_times`");
+        goto snapshot_failed;
+    }
+
+    snapshot->best_splits = calloc(game->split_count, sizeof(ls_time));
+    if (!snapshot->best_splits) {
+        LOG_ERR("snapshot creation: unable to allocate memory for `best_splits`");
+        goto snapshot_failed;
+    }
+
+    snapshot->best_segments = calloc(game->split_count, sizeof(ls_time));
+    if (!snapshot->best_segments) {
+        LOG_ERR("snapshot creation: unable to allocate memory for `best_segments`");
+        goto snapshot_failed;
+    }
+
+    memcpy(snapshot->split_times, game->split_times, game->split_count * sizeof(ls_time));
+    memcpy(snapshot->segment_times, game->segment_times, game->split_count * sizeof(ls_time));
+    memcpy(snapshot->best_splits, game->best_splits, game->split_count * sizeof(ls_time));
+    memcpy(snapshot->best_segments, game->best_segments, game->split_count * sizeof(ls_time));
+
+    for (unsigned int i = 0; i < game->split_count; ++i) {
+        if (game->split_titles[i]) {
+            snapshot->split_titles[i] = strdup(game->split_titles[i]);
+            if (!snapshot->split_titles[i]) {
+                LOG_ERRF("snapshot creation: unable to duplicate `split_titles[%zu]` in memory", i);
+                goto snapshot_failed;
+            }
+        }
+
+        if (game->split_icon_paths[i]) {
+            snapshot->split_icon_paths[i] = strdup(game->split_icon_paths[i]);
+            if (!snapshot->split_icon_paths[i]) {
+                LOG_ERRF("snapshot creation: unable to duplicate `split_icon_paths[%zu]` in memory", i);
+                goto snapshot_failed;
+            }
+        }
+    }
+
+    return snapshot;
+
+snapshot_failed:
+    ls_game_release(snapshot);
+    return NULL;
+}
+
 /**
  * Clears the current game and reset all the components.
  *
@@ -70,15 +200,52 @@ void ls_app_window_show_game(LSAppWindow* win)
     gtk_widget_set_visible(win->welcome_box->box, FALSE);
 }
 
-gpointer save_game_thread(gpointer data)
+/**
+ * @brief saves the game to the user's splits file. This function
+ * should be asynchronous and run in its own thread.
+ *
+ * @param data A valid snapshot from `create_snapshot` of the current game state to save.
+ * @return gpointer unused
+ */
+static gpointer save_game_thread(gpointer data)
 {
-    ls_game* game = data;
-    ls_game_save(game);
+    ls_game* snapshot = data;
+    ls_game_save(snapshot);
+    ls_game_release(snapshot);
+    atomic_store(&saving, false);
     return NULL;
 }
 
 void save_game(ls_game* game)
 {
-    GThread* thread = g_thread_new("save_game", save_game_thread, game);
-    g_thread_unref(thread);
+    // reject saves if we're already saving
+    if (!game || atomic_exchange(&saving, true)) {
+        return;
+    }
+
+    if (save_thread) {
+        g_thread_join(save_thread);
+        save_thread = NULL;
+    }
+
+    ls_game* snapshot = create_snapshot(game);
+    if (!snapshot) {
+        atomic_store(&saving, false);
+        return;
+    }
+
+    save_thread = g_thread_new("save_game", save_game_thread, snapshot);
+}
+
+/**
+ * @brief Join the game save thread on exit.
+ */
+void save_game_join(void)
+{
+    if (save_thread) {
+        g_thread_join(save_thread);
+        save_thread = NULL;
+    }
+
+    atomic_store(&saving, false);
 }

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -216,9 +216,16 @@ static gpointer save_game_thread(gpointer data)
     return NULL;
 }
 
+/**
+ * @brief Atomically saves the ls_game struct to the user's splits file.
+ * This function rejects new saves while another save is already running.
+ * It creates a snapshot of the current save, then runs the save on the snapshot
+ * via a worker thread.
+ *
+ * @param game The current ls_game struct to save
+ */
 void save_game(ls_game* game)
 {
-    // reject saves if we're already saving
     if (!game || atomic_exchange(&saving, true)) {
         return;
     }

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -229,11 +229,13 @@ static gpointer save_game_thread(gpointer data)
 void save_game(ls_game* game)
 {
     if (!game) {
+        LOG_WARN("Rejecting NULL game save");
         return;
     }
 
     g_mutex_lock(&save_mutex);
     if (!saving_enabled || atomic_exchange(&saving, true)) {
+        LOG_WARN("Rejecting game save during shutdown or while another save is already occurring");
         g_mutex_unlock(&save_mutex);
         return;
     }

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -10,7 +10,7 @@ extern AppConfig cfg;
 static GThread* save_thread;
 static atomic_bool saving;
 static GMutex save_mutex;
-static bool saving_enabled;
+static bool saving_enabled = true;
 
 /**
  * @brief Duplicates the ls_game as snapshot. This is useful

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -9,6 +9,8 @@ extern AppConfig cfg;
 
 static GThread* save_thread;
 static atomic_bool saving;
+static GMutex save_mutex;
+static bool saving_enabled;
 
 /**
  * @brief Duplicates the ls_game as snapshot. This is useful
@@ -226,7 +228,13 @@ static gpointer save_game_thread(gpointer data)
  */
 void save_game(ls_game* game)
 {
-    if (!game || atomic_exchange(&saving, true)) {
+    if (!game) {
+        return;
+    }
+
+    g_mutex_lock(&save_mutex);
+    if (!saving_enabled || atomic_exchange(&saving, true)) {
+        g_mutex_unlock(&save_mutex);
         return;
     }
 
@@ -238,10 +246,12 @@ void save_game(ls_game* game)
     ls_game* snapshot = create_snapshot(game);
     if (!snapshot) {
         atomic_store(&saving, false);
+        g_mutex_unlock(&save_mutex);
         return;
     }
 
     save_thread = g_thread_new("save_game", save_game_thread, snapshot);
+    g_mutex_unlock(&save_mutex);
 }
 
 /**
@@ -249,10 +259,15 @@ void save_game(ls_game* game)
  */
 void save_game_join(void)
 {
+    g_mutex_lock(&save_mutex);
+
+    // once we are exiting, prevent saves.
+    saving_enabled = false;
     if (save_thread) {
         g_thread_join(save_thread);
         save_thread = NULL;
     }
 
     atomic_store(&saving, false);
+    g_mutex_unlock(&save_mutex);
 }

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -44,7 +44,7 @@ static ls_game* create_snapshot(const ls_game* game)
         snapshot->title = strdup(game->title);
         if (!snapshot->title) {
             LOG_ERR("snapshot creation: unable to duplicate `title` in memory");
-            goto snapshot_failed;
+            goto create_snapshot_failed;
         }
     }
 
@@ -52,7 +52,7 @@ static ls_game* create_snapshot(const ls_game* game)
         snapshot->theme = strdup(game->theme);
         if (!snapshot->theme) {
             LOG_ERR("snapshot creation: unable to duplicate `theme` in memory");
-            goto snapshot_failed;
+            goto create_snapshot_failed;
         }
     }
 
@@ -60,7 +60,7 @@ static ls_game* create_snapshot(const ls_game* game)
         snapshot->theme_variant = strdup(game->theme_variant);
         if (!snapshot->theme_variant) {
             LOG_ERR("snapshot creation: unable to duplicate `theme_variant` in memory");
-            goto snapshot_failed;
+            goto create_snapshot_failed;
         }
     }
 
@@ -70,43 +70,43 @@ static ls_game* create_snapshot(const ls_game* game)
 
     if (!game->split_titles || !game->split_icon_paths || !game->split_times || !game->segment_times || !game->best_splits || !game->best_segments) {
         LOG_ERR("snapshot creation: positive split_count with empty split array(s)");
-        goto snapshot_failed;
+        goto create_snapshot_failed;
     }
 
     snapshot->split_titles = calloc(game->split_count, sizeof(char*));
     if (!snapshot->split_titles) {
         LOG_ERR("snapshot creation: unable to allocate memory for `split_titles`");
-        goto snapshot_failed;
+        goto create_snapshot_failed;
     }
 
     snapshot->split_icon_paths = calloc(game->split_count, sizeof(char*));
     if (!snapshot->split_icon_paths) {
         LOG_ERR("snapshot creation: unable to allocate memory for `split_icon_paths`");
-        goto snapshot_failed;
+        goto create_snapshot_failed;
     }
 
     snapshot->split_times = calloc(game->split_count, sizeof(ls_time));
     if (!snapshot->split_times) {
         LOG_ERR("snapshot creation: unable to allocate memory for `split_times`");
-        goto snapshot_failed;
+        goto create_snapshot_failed;
     }
 
     snapshot->segment_times = calloc(game->split_count, sizeof(ls_time));
     if (!snapshot->segment_times) {
         LOG_ERR("snapshot creation: unable to allocate memory for `segment_times`");
-        goto snapshot_failed;
+        goto create_snapshot_failed;
     }
 
     snapshot->best_splits = calloc(game->split_count, sizeof(ls_time));
     if (!snapshot->best_splits) {
         LOG_ERR("snapshot creation: unable to allocate memory for `best_splits`");
-        goto snapshot_failed;
+        goto create_snapshot_failed;
     }
 
     snapshot->best_segments = calloc(game->split_count, sizeof(ls_time));
     if (!snapshot->best_segments) {
         LOG_ERR("snapshot creation: unable to allocate memory for `best_segments`");
-        goto snapshot_failed;
+        goto create_snapshot_failed;
     }
 
     memcpy(snapshot->split_times, game->split_times, game->split_count * sizeof(ls_time));
@@ -119,7 +119,7 @@ static ls_game* create_snapshot(const ls_game* game)
             snapshot->split_titles[i] = strdup(game->split_titles[i]);
             if (!snapshot->split_titles[i]) {
                 LOG_ERRF("snapshot creation: unable to duplicate `split_titles[%u]` in memory", i);
-                goto snapshot_failed;
+                goto create_snapshot_failed;
             }
         }
 
@@ -127,14 +127,14 @@ static ls_game* create_snapshot(const ls_game* game)
             snapshot->split_icon_paths[i] = strdup(game->split_icon_paths[i]);
             if (!snapshot->split_icon_paths[i]) {
                 LOG_ERRF("snapshot creation: unable to duplicate `split_icon_paths[%u]` in memory", i);
-                goto snapshot_failed;
+                goto create_snapshot_failed;
             }
         }
     }
 
     return snapshot;
 
-snapshot_failed:
+create_snapshot_failed:
     ls_game_release(snapshot);
     return NULL;
 }

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -118,7 +118,7 @@ static ls_game* create_snapshot(const ls_game* game)
         if (game->split_titles[i]) {
             snapshot->split_titles[i] = strdup(game->split_titles[i]);
             if (!snapshot->split_titles[i]) {
-                LOG_ERRF("snapshot creation: unable to duplicate `split_titles[%zu]` in memory", i);
+                LOG_ERRF("snapshot creation: unable to duplicate `split_titles[%u]` in memory", i);
                 goto snapshot_failed;
             }
         }
@@ -126,7 +126,7 @@ static ls_game* create_snapshot(const ls_game* game)
         if (game->split_icon_paths[i]) {
             snapshot->split_icon_paths[i] = strdup(game->split_icon_paths[i]);
             if (!snapshot->split_icon_paths[i]) {
-                LOG_ERRF("snapshot creation: unable to duplicate `split_icon_paths[%zu]` in memory", i);
+                LOG_ERRF("snapshot creation: unable to duplicate `split_icon_paths[%u]` in memory", i);
                 goto snapshot_failed;
             }
         }

--- a/src/gui/game.h
+++ b/src/gui/game.h
@@ -5,4 +5,5 @@
 void ls_app_window_clear_game(LSAppWindow* win);
 void ls_app_window_show_game(LSAppWindow* win);
 void save_game(ls_game* game);
+void save_game_join(void);
 void timer_start(LSAppWindow* win);

--- a/src/gui/widgets/dialog.c
+++ b/src/gui/widgets/dialog.c
@@ -650,6 +650,7 @@ static gboolean file_picker_present(gpointer user_data)
         return G_SOURCE_REMOVE;
     }
 
+    const gsize filters_count = request->filters_count;
     set_main_window_keep_above(FALSE);
 
     GtkFileDialog* dialog = gtk_file_dialog_new();
@@ -660,11 +661,11 @@ static gboolean file_picker_present(gpointer user_data)
     GListStore* filters = NULL;
     GtkFileFilter* default_filter = NULL;
 
-    if (request->filters_count > 0) {
-        allocated_filters = g_new0(GtkFileFilter*, request->filters_count);
+    if (filters_count > 0) {
+        allocated_filters = g_new0(GtkFileFilter*, filters_count);
         filters = g_list_store_new(GTK_TYPE_FILE_FILTER);
 
-        for (gsize i = 0; i < request->filters_count; i++) {
+        for (gsize i = 0; i < filters_count; i++) {
             GtkFileFilter* filter = gtk_file_filter_new();
             gtk_file_filter_set_name(filter, request->filters[i].name);
             gtk_file_filter_add_pattern(filter, request->filters[i].pattern);
@@ -690,8 +691,8 @@ static gboolean file_picker_present(gpointer user_data)
 
     gtk_file_dialog_open(dialog, parent, NULL, file_picker_finish, file_picker_request_ref(request));
 
-    if (request->filters_count > 0) {
-        for (gsize i = 0; i < request->filters_count; i++) {
+    if (filters_count > 0) {
+        for (gsize i = 0; i < filters_count; i++) {
             g_object_unref(allocated_filters[i]);
         }
 
@@ -727,6 +728,7 @@ gboolean ls_file_picker_open(GtkWindow* parent, const LSFilePickerOptions* optio
         return FALSE;
     }
 
+    const gsize filters_count = options->filters_count;
     if (options->title == NULL || options->title[0] == '\0') {
         LOG_ERR("Invalid ls_file_picker_open usage: title was null or empty");
         return FALSE;
@@ -748,18 +750,18 @@ gboolean ls_file_picker_open(GtkWindow* parent, const LSFilePickerOptions* optio
         return FALSE;
     }
 
-    if (options->filters_count < 0 || options->filters_count > FILE_PICKER_MAX_FILTERS) {
+    if (filters_count < 0 || filters_count > FILE_PICKER_MAX_FILTERS) {
         LOG_ERR("Invalid ls_file_picker_open usage: number of filters out of bounds");
         return FALSE;
     }
 
-    if (options->filters == NULL && options->filters_count != 0) {
+    if (options->filters == NULL && filters_count != 0) {
         LOG_ERR("Invalid ls_file_picker_open usage: filters was NULL with a positive filters_count");
         return FALSE;
     }
 
     bool has_default = false;
-    for (gsize i = 0; i < options->filters_count; i++) {
+    for (gsize i = 0; i < filters_count; i++) {
         LSFilePickerFilter filter = options->filters[i];
         if (filter.name == NULL || filter.name[0] == '\0') {
             LOG_ERRF("Invalid ls_file_picker_open usage: filter[%zu].name was null or empty", i);
@@ -787,10 +789,10 @@ gboolean ls_file_picker_open(GtkWindow* parent, const LSFilePickerOptions* optio
     request->title = g_strdup(options->title);
     request->path = g_strdup(options->path);
     request->callback = callback;
-    request->filters = options->filters_count > 0 ? g_new(LSFilePickerFilter, options->filters_count) : NULL;
-    request->filters_count = options->filters_count;
+    request->filters = filters_count > 0 ? g_new(LSFilePickerFilter, filters_count) : NULL;
+    request->filters_count = filters_count;
 
-    for (gsize i = 0; i < options->filters_count; i++) {
+    for (gsize i = 0; i < filters_count; i++) {
         LSFilePickerFilter filter = options->filters[i];
         request->filters[i].name = g_strdup(filter.name);
         request->filters[i].pattern = g_strdup(filter.pattern);

--- a/src/gui/widgets/dialog.c
+++ b/src/gui/widgets/dialog.c
@@ -135,7 +135,7 @@ static gboolean is_valid_icon(const LSDialogIcon* icon)
     }
 
     if (icon->type >= LS_DIALOG_ICON_INVALID) {
-        LOG_ERRF("Invalid icon type supplied: %zu", icon->type);
+        LOG_ERRF("Invalid icon type supplied: %u", icon->type);
         return FALSE;
     }
 

--- a/src/gui/widgets/dialog.c
+++ b/src/gui/widgets/dialog.c
@@ -134,8 +134,8 @@ static gboolean is_valid_icon(const LSDialogIcon* icon)
         return TRUE;
     }
 
-    if (icon->type < 0 || icon->type >= LS_DIALOG_ICON_INVALID) {
-        LOG_ERRF("Invalid icon type supplied: %d", icon->type);
+    if (icon->type >= LS_DIALOG_ICON_INVALID) {
+        LOG_ERRF("Invalid icon type supplied: %zu", icon->type);
         return FALSE;
     }
 
@@ -750,7 +750,7 @@ gboolean ls_file_picker_open(GtkWindow* parent, const LSFilePickerOptions* optio
         return FALSE;
     }
 
-    if (filters_count < 0 || filters_count > FILE_PICKER_MAX_FILTERS) {
+    if (filters_count > FILE_PICKER_MAX_FILTERS) {
         LOG_ERR("Invalid ls_file_picker_open usage: number of filters out of bounds");
         return FALSE;
     }

--- a/src/gui/widgets/dialog.c
+++ b/src/gui/widgets/dialog.c
@@ -502,7 +502,7 @@ gboolean ls_dialog_open(GtkWindow* parent,
         return FALSE;
     }
 
-    if (options_count <= 0 || options_count > DIALOG_MAX_BUTTONS) {
+    if (options_count == 0 || options_count > DIALOG_MAX_BUTTONS) {
         LOG_ERR("Invalid ls_dialog_open usage: number of options out of bounds");
         return FALSE;
     }

--- a/src/gui/widgets/dialog.c
+++ b/src/gui/widgets/dialog.c
@@ -134,8 +134,9 @@ static gboolean is_valid_icon(const LSDialogIcon* icon)
         return TRUE;
     }
 
-    if (icon->type >= LS_DIALOG_ICON_INVALID) {
-        LOG_ERRF("Invalid icon type supplied: %u", icon->type);
+    unsigned int type = icon->type;
+    if (type >= LS_DIALOG_ICON_INVALID) {
+        LOG_ERRF("Invalid icon type supplied: %u", type);
         return FALSE;
     }
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -346,6 +346,10 @@ void ls_delta_string(char* string, long long time)
  */
 void ls_game_release(ls_game* game)
 {
+    if (game == NULL) {
+        return;
+    }
+
     LOG_DEBUG("Releasing game...");
     if (game->title) {
         free(game->title);

--- a/src/timer.c
+++ b/src/timer.c
@@ -765,7 +765,7 @@ static bool ls_write_save(json_t* json, const char* path)
         int error = errno;
         if (error != ENOENT) {
             LOG_ERRF("save game: unable to inspect path '%s': %s", path, g_strerror(error));
-            goto save_failed;
+            goto ls_write_save_failed;
         }
 
         // file doesn't exist so it cannot be a symlink
@@ -773,31 +773,31 @@ static bool ls_write_save(json_t* json, const char* path)
         real_path = strdup(path);
         if (real_path == NULL) {
             LOG_ERR("save game: failed to duplicate path string");
-            goto save_failed;
+            goto ls_write_save_failed;
         }
     } else {
         // resolve symlinks
         real_path = realpath(path, NULL);
         if (real_path == NULL) {
             LOG_ERRF("save game: failed to resolve path '%s': %s", path, g_strerror(errno));
-            goto save_failed;
+            goto ls_write_save_failed;
         }
 
         if (access(real_path, W_OK) != 0) {
             LOG_ERRF("save game: file is not writable '%s': %s", real_path, g_strerror(errno));
-            goto save_failed;
+            goto ls_write_save_failed;
         }
 
         GStatBuf file_info;
         if (g_stat(real_path, &file_info) != 0) {
             LOG_ERRF("save game: unable to inspect file '%s': %s", real_path, g_strerror(errno));
-            goto save_failed;
+            goto ls_write_save_failed;
         }
 
         // reject irregular files or hard links
         if (!S_ISREG(file_info.st_mode) || file_info.st_nlink > 1) {
             LOG_ERRF("save game: irregular file at '%s'", real_path);
-            goto save_failed;
+            goto ls_write_save_failed;
         }
     }
 
@@ -805,12 +805,12 @@ static bool ls_write_save(json_t* json, const char* path)
     if (!g_file_set_contents_full(real_path, contents, -1, G_FILE_SET_CONTENTS_CONSISTENT | G_FILE_SET_CONTENTS_DURABLE, 0666, &error)) {
         LOG_ERRF("save game: failed to write splits to '%s': %s", path, error->message);
         g_clear_error(&error);
-        goto save_failed;
+        goto ls_write_save_failed;
     }
 
     result = true;
 
-save_failed:
+ls_write_save_failed:
     free(real_path);
     free(contents);
     return result;

--- a/src/timer.c
+++ b/src/timer.c
@@ -758,14 +758,14 @@ static bool ls_write_save(json_t* json, const char* path)
         return false;
     }
 
+    bool result = false;
     GStatBuf path_info;
     char* real_path = NULL;
     if (g_lstat(path, &path_info) != 0) {
         int error = errno;
         if (error != ENOENT) {
             LOG_ERRF("save game: unable to inspect path '%s': %s", path, g_strerror(error));
-            free(contents);
-            return false;
+            goto save_failed;
         }
 
         // file doesn't exist so it cannot be a symlink
@@ -773,39 +773,31 @@ static bool ls_write_save(json_t* json, const char* path)
         real_path = strdup(path);
         if (real_path == NULL) {
             LOG_ERR("save game: failed to duplicate path string");
-            free(contents);
-            return false;
+            goto save_failed;
         }
     } else {
         // resolve symlinks
         real_path = realpath(path, NULL);
         if (real_path == NULL) {
             LOG_ERRF("save game: failed to resolve path '%s': %s", path, g_strerror(errno));
-            free(contents);
-            return false;
+            goto save_failed;
         }
 
         if (access(real_path, W_OK) != 0) {
             LOG_ERRF("save game: file is not writable '%s': %s", real_path, g_strerror(errno));
-            free(real_path);
-            free(contents);
-            return false;
+            goto save_failed;
         }
 
         GStatBuf file_info;
         if (g_stat(real_path, &file_info) != 0) {
             LOG_ERRF("save game: unable to inspect file '%s': %s", real_path, g_strerror(errno));
-            free(real_path);
-            free(contents);
-            return false;
+            goto save_failed;
         }
 
         // reject irregular files or hard links
         if (!S_ISREG(file_info.st_mode) || file_info.st_nlink > 1) {
             LOG_ERRF("save game: irregular file at '%s'", real_path);
-            free(real_path);
-            free(contents);
-            return false;
+            goto save_failed;
         }
     }
 
@@ -813,14 +805,15 @@ static bool ls_write_save(json_t* json, const char* path)
     if (!g_file_set_contents_full(real_path, contents, -1, G_FILE_SET_CONTENTS_CONSISTENT | G_FILE_SET_CONTENTS_DURABLE, 0644, &error)) {
         LOG_ERRF("save game: failed to write splits to '%s': %s", path, error->message);
         g_clear_error(&error);
-        free(real_path);
-        free(contents);
-        return false;
+        goto save_failed;
     }
 
+    result = true;
+
+save_failed:
     free(real_path);
     free(contents);
-    return true;
+    return result;
 }
 
 /**

--- a/src/timer.c
+++ b/src/timer.c
@@ -9,6 +9,7 @@
 #include "lasr/auto-splitter.h"
 
 #include <assert.h>
+#include <glib/gstdio.h>
 #include <limits.h>
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -743,6 +744,86 @@ bool ls_timer_has_rainbow_split(const ls_timer* timer)
 }
 
 /**
+ * @brief Atomically writes the splits file json to disk.
+ *
+ * @param json The full splits file json root.
+ * @param path The path to the splits file.
+ * @return bool save result
+ */
+static bool ls_write_save(json_t* json, const char* path)
+{
+    char* contents = json_dumps(json, JSON_PRESERVE_ORDER | JSON_INDENT(2));
+    if (!contents) {
+        LOG_ERR("save game: unable to create the json string");
+        return false;
+    }
+
+    GStatBuf path_info;
+    char* real_path = NULL;
+    if (g_lstat(path, &path_info) != 0) {
+        int error = errno;
+        if (error != ENOENT) {
+            LOG_ERRF("save game: unable to inspect path '%s': %s", path, g_strerror(error));
+            free(contents);
+            return false;
+        }
+
+        // file doesn't exist so it cannot be a symlink
+        // duplicate path so the call to free is always valid.
+        real_path = strdup(path);
+        if (real_path == NULL) {
+            LOG_ERR("save game: failed to duplicate path string");
+            free(contents);
+            return false;
+        }
+    } else {
+        // resolve symlinks
+        real_path = realpath(path, NULL);
+        if (real_path == NULL) {
+            LOG_ERRF("save game: failed to resolve path '%s': %s", path, g_strerror(errno));
+            free(contents);
+            return false;
+        }
+
+        if (access(real_path, W_OK) != 0) {
+            LOG_ERRF("save game: file is not writable '%s': %s", real_path, g_strerror(errno));
+            free(real_path);
+            free(contents);
+            return false;
+        }
+
+        GStatBuf file_info;
+        if (g_stat(real_path, &file_info) != 0) {
+            LOG_ERRF("save game: unable to inspect file '%s': %s", real_path, g_strerror(errno));
+            free(real_path);
+            free(contents);
+            return false;
+        }
+
+        // reject irregular files or hard links
+        if (!S_ISREG(file_info.st_mode) || file_info.st_nlink > 1) {
+            LOG_ERRF("save game: irregular file at '%s'", real_path);
+            free(real_path);
+            free(contents);
+            return false;
+        }
+    }
+
+    GError* error = NULL;
+    if (!g_file_set_contents_full(real_path, contents, -1, G_FILE_SET_CONTENTS_CONSISTENT | G_FILE_SET_CONTENTS_DURABLE, 0644, &error)) {
+        LOG_ERRF("save game: failed to write splits to '%s': %s", path, error->message);
+        g_clear_error(&error);
+        free(real_path);
+        free(contents);
+        return false;
+    }
+
+    free(real_path);
+    free(contents);
+    return true;
+}
+
+/**
  * Save the current game state to the splits file.
  *
  * @param game The ls_game object
@@ -813,18 +894,11 @@ int ls_game_save(const ls_game* game)
     if (game->height) {
         json_object_set_new(json, "height", json_integer(game->height));
     }
-    const int json_dump_result = json_dump_file(json, game->path, JSON_PRESERVE_ORDER | JSON_INDENT(2));
-    if (json_dump_result) {
-        char* json_dump = json_dumps(json, JSON_PRESERVE_ORDER | JSON_INDENT(2));
-        LOG_WARNF("Error dumping JSON:\n%s", json_dump != NULL ? json_dump : "");
-        LOG_WARNF("Error: '%d'", json_dump_result);
-        LOG_WARNF("Path: %s", game->path);
-        error = 1;
 
-        if (json_dump != NULL) {
-            free(json_dump);
-        }
+    if (!ls_write_save(json, game->path)) {
+        error = 1;
     }
+
     json_decref(json);
     return error;
 }

--- a/src/timer.c
+++ b/src/timer.c
@@ -278,8 +278,8 @@ static void ls_time_string_format(char* string,
     minutes = (time / (1000000LL * 60)) % 60;
     seconds = (time / 1000000LL) % 60;
     sprintf(dot_subsecs, ".%06lld", time % 1000000LL);
-    int display_decimals = cfg.libresplit.decimals.value.i;
     if (!serialized) {
+        int display_decimals = cfg.libresplit.decimals.value.i;
         int subsec_idx = 0;
         if (display_decimals <= 0) {
             subsec_idx = 0;

--- a/src/timer.c
+++ b/src/timer.c
@@ -802,7 +802,7 @@ static bool ls_write_save(json_t* json, const char* path)
     }
 
     GError* error = NULL;
-    if (!g_file_set_contents_full(real_path, contents, -1, G_FILE_SET_CONTENTS_CONSISTENT | G_FILE_SET_CONTENTS_DURABLE, 0644, &error)) {
+    if (!g_file_set_contents_full(real_path, contents, -1, G_FILE_SET_CONTENTS_CONSISTENT | G_FILE_SET_CONTENTS_DURABLE, 0666, &error)) {
         LOG_ERRF("save game: failed to write splits to '%s': %s", path, error->message);
         g_clear_error(&error);
         goto save_failed;

--- a/src/timer.h
+++ b/src/timer.h
@@ -35,6 +35,13 @@ typedef enum ls_time_method {
     LS_GAME_TIME = 1, /*!< LS_GAME_TIME corresponds to ls_time.game_time */
 } ls_time_method;
 
+/**
+ * @brief The game struct representing a user's loaded splits file.
+ * When splits are saved, a snapshot of this struct is created for the
+ * save operation. So if this struct is modified, then the equivalent change
+ * must be added to the snapshot function in ./src/gui/game.c `create_snapshot`
+ * as well as any memory releasing in `ls_game_release`
+ */
 typedef struct ls_game {
     char path[PATH_MAX];
     char* title;


### PR DESCRIPTION
Arguably a fix, not a feat? But currently game saving happens asynchronously but just passes around the main game object to the save game worker thread. This can be dangerous if something happens in the middle of a save operation.

This PR changes our strategy to handle the saves atomically. When a save operation is sent, we ensure we aren't already in the middle of a save (no need to over-complicate things with a queue of some sort since save operations are pretty fast so we can just throw away some kind of double click scenario that would just be the same data anyway) and then create a snapshot of the `ls_game` struct to give to the save game worker thread. This guarantees the data being saved doesn't get changed mid-operation.

Giving attempt history saves the same treatment is deferred because, at present, the save history is treated as almost an after thought that is hidden from the user. I'll tack it on to my attempt history rework that I'll eventually get to.

Also just a quick no-op change to make static analyzers be able to follow count logic more easily and not report null-derefs in dialog.c

This branch is based on #424 