### PR TITLE
feat: enhanced split history

### DIFF
--- a/docs/settings-keybinds.md
+++ b/docs/settings-keybinds.md
@@ -16,20 +16,20 @@ The settings file is divided in 3 main parts:
 
 Under the `libresplit` section, you will find the following settings:
 
-| Setting            | Type    | Description                                                  | Default        |
-| -----------------  | ------- | -----------------------------------------------------        | -------------- |
-| `start_decorated`  | Boolean | Start with window decorations                                | `false`        |
-| `start_on_top`     | Boolean | Start with window as always on top                           | `true`         |
-| `hide_cursor`      | Boolean | Hide cursor in window                                        | `false`        |
-| `global_hotkeys`   | Boolean | Enables global hotkeys                                       | `false`        |
-| `start_on_top`     | Boolean | Start with window as always on top                           | `false`        |
-| `theme`            | String  | Default theme name                                           | `"standard"`   |
-| `theme_variant`    | String  | Default theme variant                                        | `""`           |
-| `decimals`         | Integer | Number of decimals to show on the timer (from 0 to 6)        | `2`            |
-| `save_run_history` | Boolean | Save JSON files with your attempts history                   | `true`         |
-| `auto_save`        | Boolean | Performs saves automatically in-between runs                 | `true`         |
-| `ask_on_gold`      | Boolean | Ask for confirmation before resetting a run with gold splits | `true`         |
-| `ask_on_worse`     | Boolean | Ask before saving a run that is worse than PB                | `true`         |
+| Setting            | Type    | Description                                                   | Default        |
+| -----------------  | ------- | -----------------------------------------------------         | -------------- |
+| `start_decorated`  | Boolean | Start with window decorations                                 | `false`        |
+| `start_on_top`     | Boolean | Start with window as always on top                            | `true`         |
+| `hide_cursor`      | Boolean | Hide cursor in window                                         | `false`        |
+| `global_hotkeys`   | Boolean | Enables global hotkeys                                        | `false`        |
+| `start_on_top`     | Boolean | Start with window as always on top                            | `false`        |
+| `theme`            | String  | Default theme name                                            | `"standard"`   |
+| `theme_variant`    | String  | Default theme variant                                         | `""`           |
+| `decimals`         | Integer | Number of decimals to show on the timer (from 0 to 6)         | `2`            |
+| `save_run_history` | Boolean | Save JSON files with your attempts history                    | `true`         |
+| `auto_save`        | Boolean | Performs saves automatically in-between runs                  | `true`         |
+| `ask_on_gold`      | Boolean | Ask for confirmation before quitting with unsaved gold splits | `true`         |
+| `ask_on_worse`     | Boolean | Ask before saving a run that is worse than PB                 | `true`         |
 
 ### Keybind settings
 

--- a/docs/settings-keybinds.md
+++ b/docs/settings-keybinds.md
@@ -26,7 +26,8 @@ Under the `libresplit` section, you will find the following settings:
 | `theme`            | String  | Default theme name                                           | `"standard"`   |
 | `theme_variant`    | String  | Default theme variant                                        | `""`           |
 | `decimals`         | Integer | Number of decimals to show on the timer (from 0 to 6)        | `2`            |
-| `save_run_history` | Boolean | Save JSON files with old runs in the runs subdirectory       | `true`         |
+| `save_run_history` | Boolean | Save JSON files with your attempts history                   | `true`         |
+| `auto_save`        | Boolean | Performs saves automatically in-between runs                 | `true`         |
 | `ask_on_gold`      | Boolean | Ask for confirmation before resetting a run with gold splits | `true`         |
 | `ask_on_worse`     | Boolean | Ask before saving a run that is worse than PB                | `true`         |
 
@@ -56,10 +57,10 @@ Alternatively, you can use the settings Dialog by right clicking the LibreSplit 
 
 ## Wayland Workaround
 
-To work around Wayland not allowing global hotkeys it's possible to use compatibility modes.  
-On KDE this involves going to Settings -> Legacy X11 App Support -> Listening for keystrokes: Always allowed  
-This is the least secure setting, but allows LibreSplit to see your inputs.  
+To work around Wayland not allowing global hotkeys it's possible to use compatibility modes.
+On KDE this involves going to Settings -> Legacy X11 App Support -> Listening for keystrokes: Always allowed
+This is the least secure setting, but allows LibreSplit to see your inputs.
 Then in the environment variables you need to set `GDK_BACKEND=x11 LIBRESPLIT_FORCE_GLOBAL_HOTKEYS=1`
 
-A full launch command for this looks like: `GDK_BACKEND=x11 LIBRESPLIT_FORCE_GLOBAL_HOTKEYS=1 libresplit`  
+A full launch command for this looks like: `GDK_BACKEND=x11 LIBRESPLIT_FORCE_GLOBAL_HOTKEYS=1 libresplit`
 A GUI edited KDE menu application may look like this: <img width="815" height="460" alt="image" src="https://github.com/user-attachments/assets/30f86d4c-7393-4108-9aee-02ae5d2964b4" />

--- a/docs/settings-keybinds.md
+++ b/docs/settings-keybinds.md
@@ -23,16 +23,20 @@ Under the `libresplit` section, you will find the following settings:
 | `hide_cursor`                | Boolean | Hide cursor in window                                          | `false`        |
 | `global_hotkeys`             | Boolean | Enables global hotkeys                                         | `false`        |
 | `start_on_top`               | Boolean | Start with window as always on top                             | `false`        |
+| `appearance`                 | Integer | Allows you to select your light/dark mode preference*          | `System`       |
 | `theme`                      | String  | Default theme name                                             | `"standard"`   |
 | `theme_variant`              | String  | Default theme variant                                          | `""`           |
 | `decimals`                   | Integer | Number of decimals to show on the timer (from 0 to 6)          | `2`            |
 | `save_run_history`           | Boolean | Save JSON files with your attempts history                     | `true`         |
 | `run_history_next_to_splits` | Boolean | Save run history files in a directory next to your splits file | `false`        |
 | `auto_save`                  | Boolean | Performs saves automatically in-between runs                   | `true`         |
-| `ask_on_achievement`         | Boolean | Ask for confirmation before quitting with unsaved achievement* | `true`         |
+| `ask_on_achievement`         | Boolean | Ask for confirmation before quitting with unsaved achievement† | `true`         |
 | `ask_on_worse`               | Boolean | Ask before saving a run that is worse than PB                  | `true`         |
 
-*achievement here means a new PB, gold, or rainbow split.
+* This is a best effort attempt at setting the preference. On some Desktop Environments like KDE Plasma your global theme will
+  take precedence over this setting so it will appear to do nothing. In those cases, you should manage this via your System Preferences.
+
+† achievement here means a new PB, gold, or rainbow split.
 
 ### Keybind settings
 

--- a/docs/settings-keybinds.md
+++ b/docs/settings-keybinds.md
@@ -16,20 +16,21 @@ The settings file is divided in 3 main parts:
 
 Under the `libresplit` section, you will find the following settings:
 
-| Setting              | Type    | Description                                                    | Default        |
-| -------------------- | ------- | -------------------------------------------------------------- | -------------- |
-| `start_decorated`    | Boolean | Start with window decorations                                  | `false`        |
-| `start_on_top`       | Boolean | Start with window as always on top                             | `true`         |
-| `hide_cursor`        | Boolean | Hide cursor in window                                          | `false`        |
-| `global_hotkeys`     | Boolean | Enables global hotkeys                                         | `false`        |
-| `start_on_top`       | Boolean | Start with window as always on top                             | `false`        |
-| `theme`              | String  | Default theme name                                             | `"standard"`   |
-| `theme_variant`      | String  | Default theme variant                                          | `""`           |
-| `decimals`           | Integer | Number of decimals to show on the timer (from 0 to 6)          | `2`            |
-| `save_run_history`   | Boolean | Save JSON files with your attempts history                     | `true`         |
-| `auto_save`          | Boolean | Performs saves automatically in-between runs                   | `true`         |
-| `ask_on_achievement` | Boolean | Ask for confirmation before quitting with unsaved achievement* | `true`         |
-| `ask_on_worse`       | Boolean | Ask before saving a run that is worse than PB                  | `true`         |
+| Setting                      | Type    | Description                                                    | Default        |
+| ---------------------------- | ------- | -------------------------------------------------------------- | -------------- |
+| `start_decorated`            | Boolean | Start with window decorations                                  | `false`        |
+| `start_on_top`               | Boolean | Start with window as always on top                             | `true`         |
+| `hide_cursor`                | Boolean | Hide cursor in window                                          | `false`        |
+| `global_hotkeys`             | Boolean | Enables global hotkeys                                         | `false`        |
+| `start_on_top`               | Boolean | Start with window as always on top                             | `false`        |
+| `theme`                      | String  | Default theme name                                             | `"standard"`   |
+| `theme_variant`              | String  | Default theme variant                                          | `""`           |
+| `decimals`                   | Integer | Number of decimals to show on the timer (from 0 to 6)          | `2`            |
+| `save_run_history`           | Boolean | Save JSON files with your attempts history                     | `true`         |
+| `run_history_next_to_splits` | Boolean | Save run history files in a directory next to your splits file | `false`        |
+| `auto_save`                  | Boolean | Performs saves automatically in-between runs                   | `true`         |
+| `ask_on_achievement`         | Boolean | Ask for confirmation before quitting with unsaved achievement* | `true`         |
+| `ask_on_worse`               | Boolean | Ask before saving a run that is worse than PB                  | `true`         |
 
 *achievement here means a new PB, gold, or rainbow split.
 

--- a/docs/settings-keybinds.md
+++ b/docs/settings-keybinds.md
@@ -16,20 +16,22 @@ The settings file is divided in 3 main parts:
 
 Under the `libresplit` section, you will find the following settings:
 
-| Setting            | Type    | Description                                                   | Default        |
-| -----------------  | ------- | -----------------------------------------------------         | -------------- |
-| `start_decorated`  | Boolean | Start with window decorations                                 | `false`        |
-| `start_on_top`     | Boolean | Start with window as always on top                            | `true`         |
-| `hide_cursor`      | Boolean | Hide cursor in window                                         | `false`        |
-| `global_hotkeys`   | Boolean | Enables global hotkeys                                        | `false`        |
-| `start_on_top`     | Boolean | Start with window as always on top                            | `false`        |
-| `theme`            | String  | Default theme name                                            | `"standard"`   |
-| `theme_variant`    | String  | Default theme variant                                         | `""`           |
-| `decimals`         | Integer | Number of decimals to show on the timer (from 0 to 6)         | `2`            |
-| `save_run_history` | Boolean | Save JSON files with your attempts history                    | `true`         |
-| `auto_save`        | Boolean | Performs saves automatically in-between runs                  | `true`         |
-| `ask_on_gold`      | Boolean | Ask for confirmation before quitting with unsaved gold splits | `true`         |
-| `ask_on_worse`     | Boolean | Ask before saving a run that is worse than PB                 | `true`         |
+| Setting              | Type    | Description                                                    | Default        |
+| -------------------- | ------- | -------------------------------------------------------------- | -------------- |
+| `start_decorated`    | Boolean | Start with window decorations                                  | `false`        |
+| `start_on_top`       | Boolean | Start with window as always on top                             | `true`         |
+| `hide_cursor`        | Boolean | Hide cursor in window                                          | `false`        |
+| `global_hotkeys`     | Boolean | Enables global hotkeys                                         | `false`        |
+| `start_on_top`       | Boolean | Start with window as always on top                             | `false`        |
+| `theme`              | String  | Default theme name                                             | `"standard"`   |
+| `theme_variant`      | String  | Default theme variant                                          | `""`           |
+| `decimals`           | Integer | Number of decimals to show on the timer (from 0 to 6)          | `2`            |
+| `save_run_history`   | Boolean | Save JSON files with your attempts history                     | `true`         |
+| `auto_save`          | Boolean | Performs saves automatically in-between runs                   | `true`         |
+| `ask_on_achievement` | Boolean | Ask for confirmation before quitting with unsaved achievement* | `true`         |
+| `ask_on_worse`       | Boolean | Ask before saving a run that is worse than PB                  | `true`         |
+
+*achievement here means a new PB, gold, or rainbow split.
 
 ### Keybind settings
 

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,6 @@ jansson = dependency('jansson')
 openssl = dependency('openssl')
 
 libresplit_sources = files(
-    'src/attempts.c',
     'src/gui/actions.c',
     'src/gui/app_window.c',
     'src/gui/backends/x11.c',
@@ -87,6 +86,7 @@ libresplit_sources = files(
     'src/lasr/utils.c',
     'src/logging.c',
     'src/main.c',
+    'src/runs.c',
     'src/server.c',
 
     # Settings

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,7 @@ jansson = dependency('jansson')
 openssl = dependency('openssl')
 
 libresplit_sources = files(
+    'src/attempts.c',
     'src/gui/actions.c',
     'src/gui/app_window.c',
     'src/gui/backends/x11.c',

--- a/src/attempts.c
+++ b/src/attempts.c
@@ -1,0 +1,148 @@
+#include "attempts.h"
+#include "logging.h"
+#include <string.h>
+
+/**
+ * @brief Creates a new attempts array and assigns it to
+ * the pointers in attempts.
+ *
+ * @param attempts Pointer to the memory location to store the new array
+ * @return int 0 on success otherwise failure
+ */
+int ls_attempts_create(ls_attempts** attempts)
+{
+    int error = 0;
+    ls_attempts* self = calloc(1, sizeof(ls_attempts));
+    if (self == NULL) {
+        error = 1;
+        goto ls_attempts_create_error;
+    }
+
+    self->attempts = calloc(INITIAL_ATTEMPTS_ARRAY_SIZE, sizeof(ls_attempt*));
+    if (self->attempts == NULL) {
+        error = 1;
+        goto ls_attempts_create_error;
+    }
+
+    self->size = INITIAL_ATTEMPTS_ARRAY_SIZE;
+    self->count = 0;
+
+ls_attempts_create_error:
+    if (error) {
+        if (self) {
+            ls_attempts_release(self);
+        }
+
+        return error;
+    }
+
+    // free old attempts before replacing.
+    if (*attempts) {
+        ls_attempts_release(*attempts);
+        *attempts = 0;
+    }
+
+    *attempts = self;
+    return 0;
+}
+
+/**
+ * @brief Frees all attempt data for an individual attempt
+ *
+ * @param attempt the attempt instance
+ */
+static void ls_attempt_release(ls_attempt* attempt)
+{
+    free(attempt->split_times);
+    free(attempt);
+}
+
+/**
+ * @brief Frees all attempts data
+ *
+ * @param self the attempts instance
+ */
+void ls_attempts_release(ls_attempts* self)
+{
+    for (size_t i = 0; i < self->count; i++) {
+        ls_attempt_release(self->attempts[i]);
+    }
+
+    free(self->attempts);
+    free(self);
+}
+
+/**
+ * @brief Resizes the dynamic array at a rate of 1.5x its current size
+ *
+ * @param self The attempts instance
+ * @return bool Whether or not the reallocation succeeded
+ */
+static bool grow(ls_attempts* self)
+{
+    size_t new_size = self->size + ((size_t)(self->size / 2));
+    if (new_size > MAX_ATTEMPTS_ARRAY_CAPACITTY) {
+        // TODO: Dump this to disk and clear capacity.
+    }
+
+    size_t old_size = self->size;
+    ls_attempt** new_attempts = realloc(self->attempts, new_size * sizeof(ls_attempt*));
+    if (new_attempts == NULL) {
+        LOG_WARNF("unable to reallocate attempts to new size of: %zu", new_size);
+        return false;
+    }
+
+    self->attempts = new_attempts;
+    self->size = new_size;
+
+    // NULL new memory block
+    memset(self->attempts + old_size, 0, (new_size - old_size) * sizeof(ls_attempt*));
+    return true;
+}
+
+/**
+ * @brief Appends the attempt to the next empty slot in the array
+ * and increments the count. Automatically grows the array
+ * when nearing capacity.
+ *
+ * Always appends the entry to the array even if growth fails.
+ * When growth fails we should prevent new runs since storing the
+ * attempt after that point becomes impossible.
+ *
+ * @param self The attempts instance.
+ * @param attempt The attempt instance to append.
+ * @return Whether or not the array grew successfully. When no growth is needed, always true
+ */
+bool ls_attempts_append(ls_attempts* self, ls_attempt* attempt)
+{
+    self->attempts[self->count++] = attempt;
+    if (self->count == self->size) {
+        return grow(self);
+    }
+
+    return true;
+}
+
+/**
+ * @brief Clears the array and reduces memory usage.
+ *
+ * @param self The current attempts instance.
+ * @return bool Whether or not the clear succeeded.
+ */
+bool ls_attempts_clear(ls_attempts* self)
+{
+    for (size_t i = 0; i < self->count; i++) {
+        ls_attempt_release(self->attempts[i]);
+    }
+
+    free(self->attempts);
+    self->attempts = calloc(INITIAL_ATTEMPTS_ARRAY_SIZE, sizeof(ls_attempt*));
+    if (self->attempts == NULL) {
+        LOG_WARN("unable to allocate attempts");
+        return false;
+    }
+
+    self->size = INITIAL_ATTEMPTS_ARRAY_SIZE;
+    self->count = 0;
+    return true;
+}

--- a/src/attempts.h
+++ b/src/attempts.h
@@ -1,0 +1,39 @@
+#include "timer.h"
+
+/**
+ * MAX_ATTEMPTS_ARRAY_CAPACITTY ensures that at any given time
+ * the maximum amount of memory our in-memory attempts history
+ * will be MAX_ATTEMPTS_ARRAY_CAPACITTY * sizeof(ls_attempt)
+ * this would be a truly ridiculous number of runs all in one
+ * session without ever saving or closing LibreSplit.
+ *
+ * Using some conservative assumptions about how many splits are
+ * in the run, this would be roughly 1GB of ram usage.
+ *
+ * This memory is not allocated up front, this would truly require
+ * the user to sit there doing *completed* runs for years without ever
+ * saving or closing to reach that theoretical 1GB of ram usage.
+ */
+#define INITIAL_ATTEMPTS_ARRAY_SIZE 16 // 2^4
+#define MAX_ATTEMPTS_ARRAY_CAPACITTY 524288 // 2^19
+
+/**
+ * @brief This holds information about an attempt after it is complete.
+ * By complete, I mean the attempt is no longer in `ls_timer` meaning the run
+ * finished, was reset etc. This should only hold information from `ls_timer`
+ * that actually goes into the user's saved attempt history.
+ */
+typedef struct ls_attempt {
+    ls_time* split_times;
+} ls_attempt;
+
+typedef struct ls_attempts {
+    ls_attempt** attempts; /**< The attempts array */
+    size_t count; /**< The number of attempts in the array i.e. used slots */
+    size_t size; /**< The current actual allocation size of the array i.e. total slots */
+} ls_attempts;
+
+int ls_attempts_create(ls_attempts** attempts);
+void ls_attempts_release(ls_attempts* attempts);
+bool ls_attempts_append(ls_attempts* self, ls_attempt* attempt);
+bool ls_attempts_clear(ls_attempts* self);

--- a/src/gui/actions.c
+++ b/src/gui/actions.c
@@ -317,9 +317,9 @@ void quit_activated(GSimpleAction* action,
     LOG_DEBUG("Exit request sent to threads");
     win = ls_app_window_new(LS_APP(app));
 
-    // Warn if the reset will lose a gold split, and allow the user to cancel the reset if they want to keep it
-    if (win->timer && win->timer->running && (ls_timer_has_gold_split(win->timer) || ls_timer_has_rainbow_split(win->timer))) {
-        if (cfg.libresplit.ask_on_gold.value.b) {
+    // Warn if the quit will lose an achievement, and allow the user to cancel the quit if they want to keep it
+    if (ls_game_has_achievement(win->timer)) {
+        if (cfg.libresplit.ask_on_achievement.value.b) {
             display_confirm_reset_dialog(perform_quit, win);
             return;
         }

--- a/src/gui/actions.c
+++ b/src/gui/actions.c
@@ -150,6 +150,12 @@ void open_activated(GSimpleAction* action,
 static void perform_save_splits(gpointer window)
 {
     LSAppWindow* win = LS_APP_WINDOW(window);
+
+    // don't allow saving while we're in some invalid state or we're in the middle of a run.
+    if (win == NULL || win->game == NULL || win->timer == NULL || win->timer->started) {
+        return;
+    }
+
     ls_game_update_splits(win->game, win->timer);
     save_game(win->game);
 }

--- a/src/gui/actions.c
+++ b/src/gui/actions.c
@@ -272,6 +272,7 @@ void close_activated(GSimpleAction* action,
 
     win = ls_app_window_new(LS_APP(app));
     timer_stop_and_reset(win);
+    save_game_join(false);
 
     if (win->game && win->timer) {
         ls_app_window_clear_game(win);

--- a/src/gui/actions.c
+++ b/src/gui/actions.c
@@ -10,6 +10,7 @@
 #include "src/lasr/auto-splitter.h"
 #include "src/lasr/utils.h"
 #include "src/logging.h"
+#include "src/runs.h"
 #include "src/settings/settings.h"
 #include "src/settings/utils.h"
 #include <gtk/gtk.h>
@@ -106,11 +107,7 @@ void open_activated(GSimpleAction* action,
         app = parameter;
     }
 
-    win = ls_get_main_app_window(GTK_APPLICATION(app));
-    if (!win) {
-        win = ls_app_window_new(LS_APP(app));
-    }
-
+    win = ls_app_window_new(LS_APP(app));
     if (win->timer && win->timer->running) {
         ls_alert_info(GTK_WINDOW(win), "LibreSplit", "The timer is currently running", "Please stop the run before changing splits.");
         return;
@@ -173,11 +170,7 @@ void save_activated(GSimpleAction* action,
         app = parameter;
     }
 
-    win = ls_get_main_app_window(GTK_APPLICATION(app));
-    if (!win) {
-        win = ls_app_window_new(LS_APP(app));
-    }
-
+    win = ls_app_window_new(LS_APP(app));
     if (win->game && win->timer) {
         int width, height;
         gtk_window_get_default_size(GTK_WINDOW(win), &width, &height);
@@ -243,11 +236,7 @@ void reload_activated(GSimpleAction* action,
         app = parameter;
     }
 
-    win = ls_get_main_app_window(GTK_APPLICATION(app));
-    if (!win) {
-        win = ls_app_window_new(LS_APP(app));
-    }
-
+    win = ls_app_window_new(LS_APP(app));
     if (win->game) {
         path = strdup(win->game->path);
         if (!path) {
@@ -275,11 +264,7 @@ void close_activated(GSimpleAction* action,
         app = parameter;
     }
 
-    win = ls_get_main_app_window(GTK_APPLICATION(app));
-    if (!win) {
-        win = ls_app_window_new(LS_APP(app));
-    }
-
+    win = ls_app_window_new(LS_APP(app));
     timer_stop_and_reset(win);
 
     if (win->game && win->timer) {
@@ -292,6 +277,10 @@ void close_activated(GSimpleAction* action,
     if (win->game) {
         ls_game_release(win->game);
         win->game = 0;
+    }
+    if (win->runs) {
+        ls_runs_release(win->runs);
+        win->runs = 0;
     }
     gtk_widget_set_size_request(GTK_WIDGET(win), -1, -1);
 }
@@ -326,10 +315,7 @@ void quit_activated(GSimpleAction* action,
 
     atomic_store(&exit_requested, 1);
     LOG_DEBUG("Exit request sent to threads");
-    win = ls_get_main_app_window(GTK_APPLICATION(app));
-    if (!win) {
-        win = ls_app_window_new(LS_APP(app));
-    }
+    win = ls_app_window_new(LS_APP(app));
 
     // Warn if the reset will lose a gold split, and allow the user to cancel the reset if they want to keep it
     if (win->timer && win->timer->running && (ls_timer_has_gold_split(win->timer) || ls_timer_has_rainbow_split(win->timer))) {
@@ -368,11 +354,7 @@ void toggle_auto_splitter(GSimpleAction* action, GVariant* value, gpointer user_
 void menu_toggle_win_on_top(GSimpleAction* action, GVariant* value, gpointer app)
 {
     gboolean active = g_variant_get_boolean(value);
-    LSAppWindow* win = ls_get_main_app_window(GTK_APPLICATION(app));
-    if (!win) {
-        win = ls_app_window_new(LS_APP(app));
-    }
-
+    LSAppWindow* win = ls_app_window_new(LS_APP(app));
     x11_set_keep_above(GTK_WINDOW(win), active);
     win->opts.win_on_top = active;
     g_simple_action_set_state(action, value);
@@ -429,11 +411,7 @@ void open_auto_splitter(GSimpleAction* action,
         app = parameter;
     }
 
-    win = ls_get_main_app_window(GTK_APPLICATION(app));
-    if (!win) {
-        win = ls_app_window_new(LS_APP(app));
-    }
-
+    win = ls_app_window_new(LS_APP(app));
     if (win->timer && win->timer->running) {
         ls_alert_info(GTK_WINDOW(win), "LibreSplit", "The timer is currently running", "Please stop the run before changing the auto splitter.");
         return;

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -482,6 +482,37 @@ gboolean ls_app_window_step(gpointer data)
     return TRUE;
 }
 
+/**
+ * @brief Sets the block state to the main app window.
+ *
+ * @param data Pointer to whether to set the block state on or off.
+ * @return gboolean Always G_SOURCE_REMOVE to remove from the thread queue.
+ */
+static gboolean ls_app_window_set_blocked_state(gpointer data)
+{
+    gboolean block_window = *((gboolean*)data);
+    LSAppWindow* win = ls_get_main_app_window();
+    GtkWidget* window = GTK_WIDGET(win);
+    gtk_widget_set_sensitive(window, !block_window);
+    gtk_widget_set_opacity(win->container, block_window ? 0.5 : 1.0);
+    return G_SOURCE_REMOVE;
+}
+
+/**
+ * @brief Sends a request to the main GTK thread to set the window's block state.
+ * This should be used to indicate to the user that something is happening
+ * (like an in progress save) that requires interaction with LibreSplit
+ * to block for a short while.
+ *
+ * @param block_window Whether to set the block state on or off.
+ */
+void ls_app_window_set_blocked(gboolean block_window)
+{
+    gboolean* block_window_request = g_new(gboolean, 1);
+    *block_window_request = block_window;
+    g_main_context_invoke_full(NULL, G_PRIORITY_DEFAULT, ls_app_window_set_blocked_state, block_window_request, g_free);
+}
+
 gboolean ls_app_window_draw(gpointer data)
 {
     LSAppWindow* win = data;
@@ -496,6 +527,7 @@ gboolean ls_app_window_draw(gpointer data)
     } else {
         gtk_widget_queue_draw(GTK_WIDGET(win));
     }
+
     return TRUE;
 }
 

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -118,6 +118,10 @@ void ls_app_window_open(LSAppWindow* win, const char* file)
         ls_game_release(win->game);
         win->game = 0;
     }
+    if (win->attempts) {
+        ls_attempts_release(win->attempts);
+        win->attempts = 0;
+    }
     if (ls_game_create(&win->game, file, &error_msg)) {
         win->game = 0;
         if (error_msg) {
@@ -128,6 +132,8 @@ void ls_app_window_open(LSAppWindow* win, const char* file)
         }
     } else if (ls_timer_create(&win->timer, win->game)) {
         win->timer = 0;
+    } else if (ls_attempts_create(&win->attempts)) {
+        win->attempts = 0;
     } else {
         ls_app_window_show_game(win);
     }

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -113,6 +113,7 @@ void ls_app_window_open(LSAppWindow* win, const char* file)
 {
     LOG_DEBUG("Opening LibreSplit window");
     char* error_msg = NULL;
+    save_game_join(false);
 
     if (win->timer) {
         ls_app_window_clear_game(win);
@@ -378,7 +379,7 @@ void ls_app_window_destroy(GtkWidget* widget, gpointer data)
         main_win = NULL;
     }
 
-    save_game_join();
+    save_game_join(true);
     if (win->timer) {
         ls_timer_release(win->timer);
         win->timer = 0;

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -118,9 +118,9 @@ void ls_app_window_open(LSAppWindow* win, const char* file)
         ls_game_release(win->game);
         win->game = 0;
     }
-    if (win->attempts) {
-        ls_attempts_release(win->attempts);
-        win->attempts = 0;
+    if (win->runs) {
+        ls_runs_release(win->runs);
+        win->runs = 0;
     }
     if (ls_game_create(&win->game, file, &error_msg)) {
         win->game = 0;
@@ -132,8 +132,8 @@ void ls_app_window_open(LSAppWindow* win, const char* file)
         }
     } else if (ls_timer_create(&win->timer, win->game)) {
         win->timer = 0;
-    } else if (ls_attempts_create(&win->attempts)) {
-        win->attempts = 0;
+    } else if (ls_runs_create(&win->runs)) {
+        win->runs = 0;
     } else {
         ls_app_window_show_game(win);
     }

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -12,6 +12,7 @@
 #include "src/keybinds/keybinds_callbacks.h"
 #include "src/lasr/auto-splitter.h"
 #include "src/logging.h"
+#include "src/runs.h"
 #include "src/settings/settings.h"
 #include "src/settings/utils.h"
 #include "src/timer.h"
@@ -30,6 +31,8 @@ static void ls_app_init(LSApp* app)
 G_DEFINE_TYPE(LSApp, ls_app, GTK_TYPE_APPLICATION)
 
 G_DEFINE_TYPE(LSAppWindow, ls_app_window, GTK_TYPE_APPLICATION_WINDOW)
+
+static LSAppWindow* main_win = NULL;
 
 /**
  * Sets whether or not the window should be decorated
@@ -91,17 +94,19 @@ static void ls_app_window_map(GtkWidget* widget, gpointer data)
 
 LSAppWindow* ls_app_window_new(LSApp* app)
 {
+    if (main_win != NULL) {
+        return main_win;
+    }
+
     LOG_DEBUG("Creating a new LibreSplit window");
-    LSAppWindow* win;
-    win = g_object_new(LS_APP_WINDOW_TYPE, "application", app, NULL);
+    main_win = g_object_new(LS_APP_WINDOW_TYPE, "application", app, NULL);
     GtkGesture* click = gtk_gesture_click_new();
     gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(click), 0);
-    gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(click),
-        GTK_PHASE_CAPTURE);
+    gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(click), GTK_PHASE_CAPTURE);
 
     g_signal_connect(click, "pressed", G_CALLBACK(handle_button_pressed), app);
-    gtk_widget_add_controller(GTK_WIDGET(win), GTK_EVENT_CONTROLLER(click));
-    return win;
+    gtk_widget_add_controller(GTK_WIDGET(main_win), GTK_EVENT_CONTROLLER(click));
+    return main_win;
 }
 
 void ls_app_window_open(LSAppWindow* win, const char* file)
@@ -159,8 +164,17 @@ void ls_app_startup(GApplication* app)
  */
 void ls_app_activate(GApplication* app)
 {
-    LSAppWindow* win;
-    win = ls_app_window_new(LS_APP(app));
+    if (main_win != NULL) {
+        gtk_window_present(GTK_WINDOW(main_win));
+        return;
+    }
+
+    LOG_DEBUG("Initializing configuration");
+    if (!config_init()) {
+        LOG_WARN("Configuration failed to load, will use defaults");
+    }
+
+    LSAppWindow* win = ls_app_window_new(LS_APP(app));
     gtk_window_present(GTK_WINDOW(win));
 
     if (cfg.history.split_file.value.s[0] != '\0') {
@@ -179,6 +193,7 @@ void ls_app_activate(GApplication* app)
         LOG_DEBUG("Opening split file selection dialog");
         open_activated(NULL, NULL, app);
     }
+
     if (cfg.history.auto_splitter_file.value.s[0] != '\0') {
         LOG_DEBUG("Opening last used auto splitter from history");
         struct stat st = { 0 };
@@ -190,6 +205,7 @@ void ls_app_activate(GApplication* app)
             strcpy(auto_splitter_file, auto_splitters_path);
         }
     }
+
     atomic_store(&auto_splitter_enabled, cfg.libresplit.auto_splitter_enabled.value.b);
 }
 
@@ -199,13 +215,9 @@ void ls_app_open(GApplication* app,
     const gchar* hint)
 {
     LOG_DEBUG("Starting LibreSplit App");
-    int i;
-    LSAppWindow* win = ls_get_main_app_window(GTK_APPLICATION(app));
-    if (!win) {
-        win = ls_app_window_new(LS_APP(app));
-    }
+    LSAppWindow* win = ls_app_window_new(LS_APP(app));
 
-    for (i = 0; i < n_files; i++) {
+    for (gint i = 0; i < n_files; i++) {
         gchar* path = g_file_get_path(files[i]);
         if (path != NULL) {
             ls_app_window_open(win, path);
@@ -362,6 +374,10 @@ void ls_app_window_destroy(GtkWidget* widget, gpointer data)
 {
     LOG_INFO("Exiting LibreSplit. GG!");
     LSAppWindow* win = (LSAppWindow*)widget;
+    if (main_win == win) {
+        main_win = NULL;
+    }
+
     save_game_join();
     if (win->timer) {
         ls_timer_release(win->timer);
@@ -370,6 +386,10 @@ void ls_app_window_destroy(GtkWidget* widget, gpointer data)
     if (win->game) {
         ls_game_release(win->game);
         win->game = 0;
+    }
+    if (win->runs) {
+        ls_runs_release(win->runs);
+        win->runs = 0;
     }
     atomic_store(&auto_splitter_enabled, 0);
     atomic_store(&exit_requested, 1);
@@ -480,23 +500,13 @@ gboolean ls_app_window_draw(gpointer data)
 }
 
 /**
- * @brief A helper function to get the main LibreSplit AppWindow.
- * gtk_application_get_windows returns a list of windows ordered by the most
- * recently focused window. Therefore the first result is not gauranteed to be
- * the main window.
+ * @brief Returns the LibreSplit main app window.
  *
- * @param app The application
- * @return LSAppWindow* The main application window or NULL if none exists
+ * @return LSAppWindow* The main application window or NULL if none exists.
  */
-LSAppWindow* ls_get_main_app_window(GtkApplication* app)
+LSAppWindow* ls_get_main_app_window(void)
 {
-    for (GList* node = gtk_application_get_windows(app); node != NULL; node = node->next) {
-        if (LS_IS_APP_WINDOW(node->data)) {
-            return LS_APP_WINDOW(node->data);
-        }
-    }
-
-    return NULL;
+    return main_win;
 }
 
 static void ls_app_window_init(LSAppWindow* win)

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -353,9 +353,9 @@ gboolean ls_app_window_delete(GtkWindow* window, gpointer data)
 
     LSAppWindow* win = LS_APP_WINDOW(window);
 
-    // Warn if the reset will lose a gold split, and allow the user to cancel the reset if they want to keep it
-    if (win->timer && win->timer->running && (ls_timer_has_gold_split(win->timer) || ls_timer_has_rainbow_split(win->timer))) {
-        if (cfg.libresplit.ask_on_gold.value.b) {
+    // Warn if the quit will lose an achievement, and allow the user to cancel the quit if they want to keep it
+    if (ls_game_has_achievement(win->timer)) {
+        if (cfg.libresplit.ask_on_achievement.value.b) {
             display_confirm_reset_dialog(destroy_window_after_confirmation, win);
             return TRUE;
         }

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -165,16 +165,6 @@ void ls_app_startup(GApplication* app)
  */
 void ls_app_activate(GApplication* app)
 {
-    if (main_win != NULL) {
-        gtk_window_present(GTK_WINDOW(main_win));
-        return;
-    }
-
-    LOG_DEBUG("Initializing configuration");
-    if (!config_init()) {
-        LOG_WARN("Configuration failed to load, will use defaults");
-    }
-
     LSAppWindow* win = ls_app_window_new(LS_APP(app));
     gtk_window_present(GTK_WINDOW(win));
 

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -493,8 +493,11 @@ static gboolean ls_app_window_set_blocked_state(gpointer data)
 {
     gboolean block_window = *((gboolean*)data);
     LSAppWindow* win = ls_get_main_app_window();
-    GtkWidget* window = GTK_WIDGET(win);
-    gtk_widget_set_sensitive(window, !block_window);
+    if (win == NULL || gtk_widget_in_destruction(GTK_WIDGET(win))) {
+        return G_SOURCE_REMOVE;
+    }
+
+    gtk_widget_set_sensitive(GTK_WIDGET(win), !block_window);
     gtk_widget_set_opacity(win->container, block_window ? 0.5 : 1.0);
     return G_SOURCE_REMOVE;
 }

--- a/src/gui/app_window.h
+++ b/src/gui/app_window.h
@@ -78,4 +78,5 @@ void ls_app_window_open(LSAppWindow* win, const char* file);
 
 gboolean ls_app_window_step(gpointer data);
 void ls_app_window_destroy(GtkWidget* widget, gpointer data);
+void ls_app_window_set_blocked(gboolean block_window);
 gboolean ls_app_window_draw(gpointer data);

--- a/src/gui/app_window.h
+++ b/src/gui/app_window.h
@@ -3,13 +3,15 @@
 #include "src/gui/welcome_box.h"
 #include "src/keybinds/keybinds.h"
 #include "src/opts.h"
-#include "src/runs.h"
 #include "src/timer.h"
 
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
 #define WINDOW_PAD (8)
+
+/** forward declaration of ls_run from timer.h */
+typedef struct ls_runs ls_runs;
 
 G_DECLARE_FINAL_TYPE(LSApp, ls_app, LS, APP, GtkApplication)
 #define LS_APP_TYPE (ls_app_get_type())
@@ -65,7 +67,7 @@ void set_window_decorations(LSAppWindow* win);
 void toggle_decorations(LSAppWindow* win);
 void toggle_win_on_top(LSAppWindow* win);
 
-LSAppWindow* ls_get_main_app_window(GtkApplication* app);
+LSAppWindow* ls_get_main_app_window(void);
 LSAppWindow* ls_app_window_new(LSApp* app);
 void ls_app_startup(GApplication* app);
 void ls_app_activate(GApplication* app);

--- a/src/gui/app_window.h
+++ b/src/gui/app_window.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "src/attempts.h"
 #include "src/gui/welcome_box.h"
 #include "src/keybinds/keybinds.h"
 #include "src/opts.h"
+#include "src/runs.h"
 #include "src/timer.h"
 
 #include <glib-object.h>
@@ -42,7 +42,7 @@ typedef struct _LSAppWindow {
     char data_path[PATH_MAX]; /*!< The path to the libresplit user config directory */
     ls_game* game;
     ls_timer* timer;
-    ls_attempts* attempts;
+    ls_runs* runs;
     GdkDisplay* display;
     GtkWidget* container;
     LSWelcomeBox* welcome_box;

--- a/src/gui/app_window.h
+++ b/src/gui/app_window.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "src/attempts.h"
 #include "src/gui/welcome_box.h"
 #include "src/keybinds/keybinds.h"
 #include "src/opts.h"
@@ -41,6 +42,7 @@ typedef struct _LSAppWindow {
     char data_path[PATH_MAX]; /*!< The path to the libresplit user config directory */
     ls_game* game;
     ls_timer* timer;
+    ls_attempts* attempts;
     GdkDisplay* display;
     GtkWidget* container;
     LSWelcomeBox* welcome_box;

--- a/src/gui/context_menu.c
+++ b/src/gui/context_menu.c
@@ -42,6 +42,10 @@ static void sync_context_menu_state(LSAppWindow* win)
 
     action = g_action_map_lookup_action(G_ACTION_MAP(win), "always-on-top");
     g_simple_action_set_state(G_SIMPLE_ACTION(action), g_variant_new_boolean(win->opts.win_on_top));
+
+    gboolean can_save = win->game != NULL && win->timer != NULL && !win->timer->started;
+    action = g_action_map_lookup_action(G_ACTION_MAP(win), "save-splits");
+    g_simple_action_set_enabled(G_SIMPLE_ACTION(action), can_save);
 }
 
 /**

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -312,7 +312,7 @@ void save_game(ls_game* game)
 }
 
 /**
- * @brief Join the game save thread on exit.
+ * @brief Join the game save thread.
  */
 void save_game_join(bool exiting)
 {

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -1,6 +1,7 @@
 #include "game.h"
 #include "src/gui/component/components.h"
 #include "src/gui/theming.h"
+#include "src/gui/widgets/alert.h"
 #include "src/logging.h"
 #include "src/runs.h"
 #include "src/settings/definitions.h"
@@ -221,13 +222,24 @@ void ls_app_window_show_game(LSAppWindow* win)
 static gpointer save_game_thread(gpointer data)
 {
     save_data* snapshot = data;
+    LSAppWindow* win = ls_get_main_app_window();
+    GtkWindow* window = win ? GTK_WINDOW(win) : NULL;
     int result = ls_game_save(snapshot->game);
+    if (result) {
+        ls_alert_warning(window, "Save Failed", "Save Failed", "We were unable to save your game.\n If this continues check your logs for errors.");
+        goto save_game_thread_finished;
+    }
 
     if (snapshot->runs) {
-        ls_runs_save(snapshot->runs, snapshot->game);
+        if (ls_runs_save(snapshot->runs, snapshot->game)) {
+            ls_alert_warning(window, "Save Failed", "Save Failed", "We were unable to save your runs history.\n If this continues check your logs for errors.");
+            goto save_game_thread_finished;
+        }
+
         ls_runs_clear(snapshot->runs);
     }
 
+save_game_thread_finished:
     ls_game_release(snapshot->game);
     free(snapshot);
 
@@ -301,17 +313,19 @@ void save_game(ls_game* game)
 /**
  * @brief Join the game save thread on exit.
  */
-void save_game_join(void)
+void save_game_join(bool exiting)
 {
     g_mutex_lock(&save_mutex);
 
-    // once we are exiting, prevent saves.
-    saving_enabled = false;
+    if (exiting) {
+        // once we are exiting, prevent saves.
+        saving_enabled = false;
+    }
+
     if (save_thread) {
         g_thread_join(save_thread);
         save_thread = NULL;
     }
 
-    atomic_store(&saving, false);
     g_mutex_unlock(&save_mutex);
 }

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -242,15 +242,15 @@ static gpointer save_game_thread(gpointer data)
     }
 
 save_game_thread_finished:
+    // if the game saved successfully, call ls_game_saved event.
+    if (result == 0 && main_win) {
+        ls_game_saved(LS_APP_WINDOW(main_win)->game);
+    }
+
     g_clear_object(&main_win);
     g_weak_ref_clear(&snapshot->main_win);
     ls_game_release(snapshot->game);
     free(snapshot);
-
-    // if the game saved successfully, call ls_game_saved event.
-    if (result == 0) {
-        ls_game_saved();
-    }
 
     atomic_store(&saving, false);
     ls_app_window_set_blocked(FALSE);

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -294,6 +294,7 @@ void save_game(ls_game* game)
 
     snapshot->game = create_snapshot(game);
     if (snapshot->game == NULL) {
+        free(snapshot);
         atomic_store(&saving, false);
         g_mutex_unlock(&save_mutex);
         return;

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -215,7 +215,7 @@ void ls_app_window_show_game(LSAppWindow* win)
  * should be asynchronous and run in its own thread.
  *
  * @param data save_data containing a valid snapshot from `create_snapshot` of the current game state to save
- *              along with an optional valid snapshot from `ls_runs_snapshot` of unsaved runs history.
+ *              along with an optional (live) pointer to unsaved runs history.
  * @return gpointer unused
  */
 static gpointer save_game_thread(gpointer data)

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -2,8 +2,10 @@
 #include "src/gui/component/components.h"
 #include "src/gui/theming.h"
 #include "src/logging.h"
+#include "src/runs.h"
 #include "src/settings/definitions.h"
 #include <gtk/gtk.h>
+#include <unistd.h>
 
 extern AppConfig cfg;
 
@@ -11,6 +13,11 @@ static GThread* save_thread;
 static atomic_bool saving;
 static GMutex save_mutex;
 static bool saving_enabled = true;
+
+typedef struct save_data {
+    ls_game* game;
+    ls_runs* runs;
+} save_data;
 
 /**
  * @brief Duplicates the ls_game as snapshot. This is useful
@@ -207,16 +214,31 @@ void ls_app_window_show_game(LSAppWindow* win)
  * @brief saves the game to the user's splits file. This function
  * should be asynchronous and run in its own thread.
  *
- * @param data A valid snapshot from `create_snapshot` of the current game state to save.
+ * @param data save_data containing a valid snapshot from `create_snapshot` of the current game state to save
+ *              along with an optional valid snapshot from `ls_runs_snapshot` of unsaved runs history.
  * @return gpointer unused
  */
 static gpointer save_game_thread(gpointer data)
 {
-    ls_game* snapshot = data;
-    ls_game_save(snapshot);
-    ls_game_release(snapshot);
+    save_data* snapshot = data;
+    ls_game_save(snapshot->game);
+
+    if (snapshot->runs) {
+        ls_runs_save(snapshot->runs, snapshot->game);
+        ls_runs_clear(snapshot->runs);
+    }
+
+    ls_game_release(snapshot->game);
+    free(snapshot);
+
     atomic_store(&saving, false);
+    ls_app_window_set_blocked(FALSE);
     return NULL;
+}
+
+bool is_saving(void)
+{
+    return atomic_load(&saving);
 }
 
 /**
@@ -246,13 +268,27 @@ void save_game(ls_game* game)
         save_thread = NULL;
     }
 
-    ls_game* snapshot = create_snapshot(game);
-    if (!snapshot) {
+    save_data* snapshot = calloc(1, sizeof(save_data));
+    if (snapshot == NULL) {
         atomic_store(&saving, false);
         g_mutex_unlock(&save_mutex);
         return;
     }
 
+    snapshot->game = create_snapshot(game);
+    if (snapshot->game == NULL) {
+        atomic_store(&saving, false);
+        g_mutex_unlock(&save_mutex);
+        return;
+    }
+
+    if (cfg.libresplit.save_run_history.value.b) {
+        LSAppWindow* win = ls_get_main_app_window();
+        snapshot->runs = win->runs;
+    }
+
+    // This should be imperceivable but block on save in case the user's machine is slow.
+    ls_app_window_set_blocked(TRUE);
     save_thread = g_thread_new("save_game", save_game_thread, snapshot);
     g_mutex_unlock(&save_mutex);
 }

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -18,6 +18,7 @@ static bool saving_enabled = true;
 typedef struct save_data {
     ls_game* game;
     ls_runs* runs;
+    GWeakRef main_win;
 } save_data;
 
 /**
@@ -222,24 +223,27 @@ void ls_app_window_show_game(LSAppWindow* win)
 static gpointer save_game_thread(gpointer data)
 {
     save_data* snapshot = data;
-    LSAppWindow* win = ls_get_main_app_window();
-    GtkWindow* window = win ? GTK_WINDOW(win) : NULL;
+    GObject* main_win = g_weak_ref_get(&snapshot->main_win);
+    GtkWindow* win = main_win ? GTK_WINDOW(main_win) : NULL;
     int result = ls_game_save(snapshot->game);
     if (result) {
-        ls_alert_warning(window, "Save Failed", "Save Failed", "We were unable to save your game.\n If this continues check your logs for errors.");
+        ls_alert_warning(win, "Save Failed", "Save Failed", "We were unable to save your game.\n If this continues check your logs for errors.");
         goto save_game_thread_finished;
     }
 
     if (snapshot->runs) {
         if (ls_runs_save(snapshot->runs, snapshot->game)) {
-            ls_alert_warning(window, "Save Failed", "Save Failed", "We were unable to save your runs history.\n If this continues check your logs for errors.");
+            ls_alert_warning(win, "Save Failed", "Save Failed", "We were unable to save your runs history.\n If this continues check your logs for errors.");
             goto save_game_thread_finished;
         }
 
+        // TODO: This should not be possible to fail so maybe quit libresplit if it does...
         ls_runs_clear(snapshot->runs);
     }
 
 save_game_thread_finished:
+    g_clear_object(&main_win);
+    g_weak_ref_clear(&snapshot->main_win);
     ls_game_release(snapshot->game);
     free(snapshot);
 
@@ -300,8 +304,10 @@ void save_game(ls_game* game)
         return;
     }
 
+    LSAppWindow* win = ls_get_main_app_window();
+    g_weak_ref_init(&snapshot->main_win, win ? G_OBJECT(win) : NULL);
+
     if (cfg.libresplit.save_run_history.value.b) {
-        LSAppWindow* win = ls_get_main_app_window();
         snapshot->runs = win->runs;
     }
 

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -221,7 +221,7 @@ void ls_app_window_show_game(LSAppWindow* win)
 static gpointer save_game_thread(gpointer data)
 {
     save_data* snapshot = data;
-    ls_game_save(snapshot->game);
+    int result = ls_game_save(snapshot->game);
 
     if (snapshot->runs) {
         ls_runs_save(snapshot->runs, snapshot->game);
@@ -230,6 +230,11 @@ static gpointer save_game_thread(gpointer data)
 
     ls_game_release(snapshot->game);
     free(snapshot);
+
+    // if the game saved successfully, call ls_game_saved event.
+    if (result == 0) {
+        ls_game_saved();
+    }
 
     atomic_store(&saving, false);
     ls_app_window_set_blocked(FALSE);

--- a/src/gui/game.h
+++ b/src/gui/game.h
@@ -4,6 +4,7 @@
 
 void ls_app_window_clear_game(LSAppWindow* win);
 void ls_app_window_show_game(LSAppWindow* win);
+bool is_saving(void);
 void save_game(ls_game* game);
 void save_game_join(void);
 void timer_start(LSAppWindow* win);

--- a/src/gui/game.h
+++ b/src/gui/game.h
@@ -6,5 +6,5 @@ void ls_app_window_clear_game(LSAppWindow* win);
 void ls_app_window_show_game(LSAppWindow* win);
 bool is_saving(void);
 void save_game(ls_game* game);
-void save_game_join(void);
+void save_game_join(bool exiting);
 void timer_start(LSAppWindow* win);

--- a/src/gui/timer.c
+++ b/src/gui/timer.c
@@ -172,9 +172,9 @@ void timer_cancel_run(LSAppWindow* win)
         return;
     }
 
-    // Warn if the reset will lose a gold split, and allow the user to cancel the reset if they want to keep it
+    // Warn if the cancel will lose a gold/rainbow split, and allow the user to abort the cancel if they want to keep it
     if (ls_timer_has_gold_split(win->timer) || ls_timer_has_rainbow_split(win->timer)) {
-        if (cfg.libresplit.ask_on_gold.value.b) {
+        if (cfg.libresplit.ask_on_achievement.value.b) {
             display_confirm_reset_dialog(perform_cancel_run, win);
             return;
         }

--- a/src/gui/timer.c
+++ b/src/gui/timer.c
@@ -45,8 +45,8 @@ void timer_start_split(LSAppWindow* win)
         return;
 
     if (!win->timer->started) { // To start again a reset needs to happen
-        if (ls_timer_start(win->timer)) {
-            save_game(win->game);
+        if (!ls_timer_start(win->timer)) {
+            return;
         }
     } else {
         ls_timer_split(win->timer);
@@ -73,8 +73,8 @@ void timer_start(LSAppWindow* win)
     if (win->timer->running)
         return; // Timer is already running, do nothing
 
-    if (ls_timer_start(win->timer)) {
-        save_game(win->game);
+    if (!ls_timer_start(win->timer)) {
+        return;
     }
 
     for (GList* l = win->components; l != NULL; l = l->next) {

--- a/src/gui/timer.c
+++ b/src/gui/timer.c
@@ -23,7 +23,9 @@ void timer_stop_and_reset(LSAppWindow* win)
     if (ls_timer_reset(win->timer, win->game)) {
         ls_app_window_clear_game(win);
         ls_app_window_show_game(win);
-        save_game(win->game);
+        if (cfg.libresplit.auto_save.value.b) {
+            save_game(win->game);
+        }
     }
 
     for (GList* l = win->components; l != NULL; l = l->next) {
@@ -104,7 +106,9 @@ void timer_stop_or_reset(LSAppWindow* win)
         if (ls_timer_reset(win->timer, win->game)) {
             ls_app_window_clear_game(win);
             ls_app_window_show_game(win);
-            save_game(win->game);
+            if (cfg.libresplit.auto_save.value.b) {
+                save_game(win->game);
+            }
         }
     }
 
@@ -140,7 +144,9 @@ static void perform_cancel_run(gpointer window)
     ls_timer_cancel(win->timer);
     ls_app_window_clear_game(win);
     ls_app_window_show_game(win);
-    save_game(win->game);
+    if (cfg.libresplit.auto_save.value.b) {
+        save_game(win->game);
+    }
 
     for (GList* l = win->components; l != NULL; l = l->next) {
         LSComponent* component = l->data;

--- a/src/gui/widgets/dialog.c
+++ b/src/gui/widgets/dialog.c
@@ -74,7 +74,7 @@ void set_main_window_keep_above(gboolean setting)
         return;
     }
 
-    LSAppWindow* win = ls_get_main_app_window(GTK_APPLICATION(app));
+    LSAppWindow* win = ls_get_main_app_window();
     if (win != NULL && win->opts.win_on_top) {
         x11_set_keep_above(GTK_WINDOW(win), setting);
     }

--- a/src/gui/widgets/help_dialog.c
+++ b/src/gui/widgets/help_dialog.c
@@ -57,7 +57,7 @@ static gboolean build_help_dialog(gpointer data)
 
     LOG_DEBUG("Opening Help Window...");
     GtkApplication* app = GTK_APPLICATION(data);
-    LSAppWindow* win = ls_get_main_app_window(app);
+    LSAppWindow* win = ls_get_main_app_window();
     if (win == NULL) {
         LOG_ERR("Main application window was not found");
         return G_SOURCE_REMOVE;

--- a/src/gui/widgets/settings_dialog.c
+++ b/src/gui/widgets/settings_dialog.c
@@ -233,7 +233,7 @@ static gboolean build_settings_dialog(gpointer data)
 
     LOG_INFO("Creating the settings dialog...");
     GtkApplication* app = GTK_APPLICATION(data);
-    LSAppWindow* win = ls_get_main_app_window(app);
+    LSAppWindow* win = ls_get_main_app_window();
     if (win == NULL) {
         LOG_ERR("Main application window was not found");
         return G_SOURCE_REMOVE;

--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,7 @@ void handle_ctl_command(CTLCommand command)
         return;
     }
 
-    LSAppWindow* win = ls_get_main_app_window(GTK_APPLICATION(g_app));
+    LSAppWindow* win = ls_get_main_app_window();
     if (!win) {
         LOG_INFO("No window available to handle commands");
         return;

--- a/src/runs.c
+++ b/src/runs.c
@@ -58,9 +58,9 @@ static void ls_attempt_release(ls_attempt* attempt)
 }
 
 /**
- * @brief Frees all attempts data
+ * @brief Frees all runs data
  *
- * @param self the attempts instance
+ * @param self the runs instance
  */
 void ls_runs_release(ls_runs* self)
 {
@@ -75,7 +75,7 @@ void ls_runs_release(ls_runs* self)
 /**
  * @brief Resizes the dynamic array at a rate of 1.5x its current size
  *
- * @param self The attempts instance
+ * @param self The runs instance
  * @return bool Whether or not the reallocation succeeded
  */
 static bool grow(ls_runs* self)
@@ -88,7 +88,7 @@ static bool grow(ls_runs* self)
     size_t old_size = self->size;
     ls_attempt** new_attempts = realloc(self->attempts, new_size * sizeof(ls_attempt*));
     if (new_attempts == NULL) {
-        LOG_WARNF("unable to reallocate attempts to new size of: %zu", new_size);
+        LOG_WARNF("unable to reallocate runs to new size of: %zu", new_size);
         return false;
     }
 
@@ -109,9 +109,9 @@ static bool grow(ls_runs* self)
  * When growth fails we should prevent new runs since storing the
  * attempt after that point becomes impossible.
  *
- * @param self The attempts instance.
- * @param attempt The attempt instance to append.
- * @return Whether or not the array grew successfully. When no growth is needed, always true
+ * @param self The runs instance.
+ * @param attempt The attempt instance to append to runs.
+ * @return Whether or not the array grew successfully. When no growth is needed, always true.
  */
 bool ls_runs_append(ls_runs* self, ls_attempt* attempt)
 {
@@ -126,7 +126,7 @@ bool ls_runs_append(ls_runs* self, ls_attempt* attempt)
 /**
  * @brief Clears the array and reduces memory usage.
  *
- * @param self The current attempts instance.
+ * @param self The current runs instance.
  * @return bool Whether or not the clear succeeded.
  */
 bool ls_runs_clear(ls_runs* self)
@@ -138,7 +138,7 @@ bool ls_runs_clear(ls_runs* self)
     free(self->attempts);
     self->attempts = calloc(INITIAL_ATTEMPTS_ARRAY_SIZE, sizeof(ls_attempt*));
     if (self->attempts == NULL) {
-        LOG_WARN("unable to allocate attempts");
+        LOG_WARN("unable to allocate runs after clear");
         return false;
     }
 

--- a/src/runs.c
+++ b/src/runs.c
@@ -86,12 +86,18 @@ ls_runs_create_error:
  */
 static void ls_attempt_release(ls_attempt* attempt)
 {
+    if (attempt == NULL) {
+        return;
+    }
+
     free(attempt->split_times);
     free(attempt->segment_times);
     free(attempt->reason);
 
-    for (unsigned int i = 0; i < attempt->split_count; ++i) {
-        free(attempt->split_titles[i]);
+    if (attempt->split_times) {
+        for (unsigned int i = 0; i < attempt->split_count; ++i) {
+            free(attempt->split_titles[i]);
+        }
     }
 
     free(attempt->split_titles);
@@ -402,7 +408,7 @@ int ls_runs_save(const ls_runs* snapshot, const ls_game* game)
         }
 
         json_object_set_new(json, "splits", splits);
-        json_array_append(runs, json);
+        json_array_append_new(runs, json);
     }
 
     if (!ls_write_save(runs, path)) {

--- a/src/runs.c
+++ b/src/runs.c
@@ -255,7 +255,7 @@ ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason)
     }
 
     attempt->reason = strdup(reason);
-    if (attempt->segment_times == NULL) {
+    if (attempt->reason == NULL) {
         LOG_WARN("unable to duplicate `reason` for the attempt");
         goto ls_runs_new_attempt_failed;
     }

--- a/src/runs.c
+++ b/src/runs.c
@@ -94,7 +94,7 @@ static void ls_attempt_release(ls_attempt* attempt)
     free(attempt->segment_times);
     free(attempt->reason);
 
-    if (attempt->split_times) {
+    if (attempt->split_titles) {
         for (unsigned int i = 0; i < attempt->curr_split; ++i) {
             free(attempt->split_titles[i]);
         }

--- a/src/runs.c
+++ b/src/runs.c
@@ -1,48 +1,48 @@
-#include "attempts.h"
+#include "runs.h"
 #include "logging.h"
 #include <string.h>
 
 /**
  * @brief Creates a new attempts array and assigns it to
- * the pointers in attempts.
+ * the pointers in runs.
  *
- * @param attempts Pointer to the memory location to store the new array
+ * @param runs Pointer to the memory location to store the new array
  * @return int 0 on success otherwise failure
  */
-int ls_attempts_create(ls_attempts** attempts)
+int ls_runs_create(ls_runs** runs)
 {
     int error = 0;
-    ls_attempts* self = calloc(1, sizeof(ls_attempts));
+    ls_runs* self = calloc(1, sizeof(ls_runs));
     if (self == NULL) {
         error = 1;
-        goto ls_attempts_create_error;
+        goto ls_runs_create_error;
     }
 
     self->attempts = calloc(INITIAL_ATTEMPTS_ARRAY_SIZE, sizeof(ls_attempt*));
     if (self->attempts == NULL) {
         error = 1;
-        goto ls_attempts_create_error;
+        goto ls_runs_create_error;
     }
 
     self->size = INITIAL_ATTEMPTS_ARRAY_SIZE;
     self->count = 0;
 
-ls_attempts_create_error:
+ls_runs_create_error:
     if (error) {
         if (self) {
-            ls_attempts_release(self);
+            ls_runs_release(self);
         }
 
         return error;
     }
 
-    // free old attempts before replacing.
-    if (*attempts) {
-        ls_attempts_release(*attempts);
-        *attempts = 0;
+    // free old runs before replacing.
+    if (*runs) {
+        ls_runs_release(*runs);
+        *runs = 0;
     }
 
-    *attempts = self;
+    *runs = self;
     return 0;
 }
 
@@ -62,7 +62,7 @@ static void ls_attempt_release(ls_attempt* attempt)
  *
  * @param self the attempts instance
  */
-void ls_attempts_release(ls_attempts* self)
+void ls_runs_release(ls_runs* self)
 {
     for (size_t i = 0; i < self->count; i++) {
         ls_attempt_release(self->attempts[i]);
@@ -78,7 +78,7 @@ void ls_attempts_release(ls_attempts* self)
  * @param self The attempts instance
  * @return bool Whether or not the reallocation succeeded
  */
-static bool grow(ls_attempts* self)
+static bool grow(ls_runs* self)
 {
     size_t new_size = self->size + ((size_t)(self->size / 2));
     if (new_size > MAX_ATTEMPTS_ARRAY_CAPACITTY) {
@@ -113,7 +113,7 @@ static bool grow(ls_attempts* self)
  * @param attempt The attempt instance to append.
  * @return Whether or not the array grew successfully. When no growth is needed, always true
  */
-bool ls_attempts_append(ls_attempts* self, ls_attempt* attempt)
+bool ls_runs_append(ls_runs* self, ls_attempt* attempt)
 {
     self->attempts[self->count++] = attempt;
     if (self->count == self->size) {
@@ -129,7 +129,7 @@ bool ls_attempts_append(ls_attempts* self, ls_attempt* attempt)
  * @param self The current attempts instance.
  * @return bool Whether or not the clear succeeded.
  */
-bool ls_attempts_clear(ls_attempts* self)
+bool ls_runs_clear(ls_runs* self)
 {
     for (size_t i = 0; i < self->count; i++) {
         ls_attempt_release(self->attempts[i]);

--- a/src/runs.c
+++ b/src/runs.c
@@ -1,6 +1,34 @@
 #include "runs.h"
 #include "logging.h"
+#include "src/gui/app_window.h"
+#include "src/settings/utils.h"
 #include <string.h>
+#include <sys/stat.h>
+
+/**
+ * @brief Sets today's date to the date buffer in YYYY-MM-DD format.
+ *
+ * @param date Pointer to a string of at least length 16.
+ * @return bool Whether or not fetching today's date was successful.
+ */
+static bool set_date(char* date)
+{
+    time_t now = time(NULL);
+    if (now == (time_t)-1) {
+        return false;
+    }
+
+    struct tm local_time;
+    if (localtime_r(&now, &local_time) == NULL) {
+        return false;
+    }
+
+    if (strftime(date, 16, "%Y-%m-%d", &local_time) == 0) {
+        return false;
+    }
+
+    return true;
+}
 
 /**
  * @brief Creates a new attempts array and assigns it to
@@ -14,6 +42,11 @@ int ls_runs_create(ls_runs** runs)
     int error = 0;
     ls_runs* self = calloc(1, sizeof(ls_runs));
     if (self == NULL) {
+        error = 1;
+        goto ls_runs_create_error;
+    }
+
+    if (!set_date(self->date)) {
         error = 1;
         goto ls_runs_create_error;
     }
@@ -154,6 +187,7 @@ bool ls_runs_clear(ls_runs* self)
     free(self->attempts);
     self->attempts = calloc(INITIAL_ATTEMPTS_ARRAY_SIZE, sizeof(ls_attempt*));
     if (self->attempts == NULL) {
+        // This should never happens since we should have freed more memory than we're requesting.
         LOG_WARN("unable to allocate runs after clear");
         return false;
     }
@@ -173,6 +207,11 @@ bool ls_runs_clear(ls_runs* self)
  */
 ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason)
 {
+    ls_time final_time = ls_timer_get_time(timer, true);
+    if (ls_time_lte_zero(final_time)) {
+        return NULL;
+    }
+
     if (reason == NULL) {
         LOG_WARN("invalid NULL reason provided");
         return NULL;
@@ -185,8 +224,11 @@ ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason)
     }
 
     const size_t split_count = timer->game->split_count;
-    size_t time_size = split_count * sizeof(ls_time);
+    const size_t time_size = split_count * sizeof(ls_time);
     attempt->split_count = split_count;
+    strcpy(attempt->start_time, timer->start_time);
+    ls_run_set_time(attempt->end_time);
+
     attempt->split_times = calloc(1, time_size);
     if (attempt->split_times == NULL) {
         LOG_WARN("unable to allocate `split_times` for the attempt");
@@ -206,14 +248,14 @@ ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason)
     }
 
     attempt->split_titles = calloc(1, split_count * sizeof(char*));
-    if (attempt->segment_times == NULL) {
+    if (attempt->split_titles == NULL) {
         LOG_WARN("unable to allocate `segment_times` for the attempt");
         goto ls_runs_new_attempt_failed;
     }
 
     for (unsigned int i = 0; i < split_count; ++i) {
         attempt->split_titles[i] = strdup(timer->game->split_titles[i]);
-        if (attempt->segment_times == NULL) {
+        if (attempt->split_titles[i] == NULL) {
             LOG_WARNF("unable to duplicate `split_titles[%u]` for the attempt", i);
             goto ls_runs_new_attempt_failed;
         }
@@ -221,10 +263,123 @@ ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason)
 
     memcpy(attempt->split_times, timer->split_times, time_size);
     memcpy(attempt->segment_times, timer->segment_times, time_size);
-    attempt->final_time = ls_timer_get_time(timer, true);
+    attempt->final_time = final_time;
     return attempt;
 
 ls_runs_new_attempt_failed:
     ls_attempt_release(attempt);
     return NULL;
+}
+
+static json_t* get_or_create_runs_history(const ls_game* game, const char* date, char* path, json_error_t* json_error)
+{
+    const char* name = strrchr(game->path, '/');
+    name = name ? name + 1 : game->path;
+    const char* dot = strrchr(name, '.');
+
+    size_t len = strlen(game->path);
+    if (dot && dot != name && strcmp(name, "..") != 0) {
+        len = (size_t)(dot - game->path);
+    }
+
+    memcpy(path, game->path, len);
+    path[len] = '\0';
+
+    LSAppWindow* win = ls_get_main_app_window();
+    if (!create_default_directory(game->title, path, 0755, win ? GTK_WINDOW(win) : NULL)) {
+        return NULL;
+    }
+
+    char history_file[FILENAME_MAX + 1];
+    snprintf(history_file, FILENAME_MAX + 1, "/%s.json", date);
+    size_t history_file_len = strlen(history_file);
+    memcpy(path + len, history_file, history_file_len + 1);
+
+    struct stat st = { 0 };
+    if (stat(path, &st) == -1) {
+        GError* error = NULL;
+        if (!g_file_set_contents_full(path, "[]", -1, G_FILE_SET_CONTENTS_CONSISTENT | G_FILE_SET_CONTENTS_DURABLE, 0666, &error)) {
+            LOG_ERRF("save game: failed to create run history file at '%s': %s", path, error->message);
+            g_clear_error(&error);
+            return NULL;
+        }
+    }
+
+    return json_load_file(path, 0, json_error);
+}
+
+/**
+ * Saves the current runs history snapshot to today's runs file.
+ *
+ * @param snapshot The runs snapshot to save.
+ * @return int Any error code while saving.
+ */
+int ls_runs_save(const ls_runs* snapshot, const ls_game* game)
+{
+    LOG_DEBUG("Saving attempts history...");
+
+    char path[PATH_MAX];
+    json_error_t json_error = { 0 };
+    json_t* runs = get_or_create_runs_history(game, snapshot->date, path, &json_error);
+    if (!runs) {
+        if (json_error.line) {
+            LOG_ERRF("%s (%d:%d)", json_error.text, json_error.line, json_error.column);
+        }
+
+        return 1;
+    }
+
+    int error = 0;
+    for (size_t i = 0; i < snapshot->count; ++i) {
+        ls_attempt* attempt = snapshot->attempts[i];
+
+        // Root JSON Object
+        json_t* json = json_object();
+        json_t* final = json_object();
+        json_time_set(final, &attempt->final_time);
+        json_object_set_new(json, "start_time", json_string(attempt->start_time));
+        json_object_set_new(json, "end_time", json_string(attempt->end_time));
+        json_object_set_new(json, "final_time", final);
+        json_object_set_new(json, "reason", json_string(attempt->reason));
+
+        // Splits Array
+        json_t* splits = json_array();
+
+        for (size_t j = 0; j < attempt->split_count; ++j) {
+            json_t* split = json_object();
+
+            // Title
+            json_object_set_new(split, "title", json_string(attempt->split_titles[j]));
+
+            // Check if time is valid, avoids saving time on skipped splits
+            if (is_time_valid(attempt->split_times[j].game_time) && is_time_valid(attempt->split_times[j].real_time)) {
+                json_t* time = json_object();
+                json_time_set(time, &attempt->split_times[j]);
+                json_object_set_new(split, "time", time);
+                // Check if segment time is valid, avoids saving segment time AFTER skipped split
+                if (is_time_valid(attempt->segment_times[j].game_time) && is_time_valid(attempt->segment_times[j].real_time)) {
+                    json_t* segment = json_object();
+                    json_time_set(segment, &attempt->segment_times[j]);
+                    json_object_set_new(split, "segment", segment);
+                } else {
+                    json_object_set_new(split, "segment", json_null());
+                }
+            } else {
+                json_object_set_new(split, "time", json_null());
+                json_object_set_new(split, "segment", json_null());
+            }
+
+            json_array_append_new(splits, split);
+        }
+
+        json_object_set_new(json, "splits", splits);
+        json_array_append(runs, json);
+    }
+
+    if (!ls_write_save(runs, path)) {
+        error = 1;
+    }
+
+    json_decref(runs);
+    return error;
 }

--- a/src/runs.c
+++ b/src/runs.c
@@ -69,6 +69,9 @@ void ls_runs_release(ls_runs* self)
     }
 
     free(self->attempts);
+    self->count = 0;
+    self->size = 0;
+
     free(self);
 }
 

--- a/src/runs.c
+++ b/src/runs.c
@@ -133,6 +133,7 @@ static bool ls_attempts_grow(ls_runs* self)
     if (self->size >= MAX_ATTEMPTS_ARRAY_CAPACITTY) {
         LSAppWindow* win = ls_get_main_app_window();
         if (win && win->game) {
+            // TODO: If this fails we don't handle it and then throw away attemp
             ls_runs_save(self, win->game);
         }
 
@@ -234,8 +235,10 @@ ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason)
     }
 
     const size_t split_count = timer->game->split_count;
-    const size_t time_size = split_count * sizeof(ls_time);
+    const size_t curr_split = timer->curr_split;
+    const size_t time_size = curr_split * sizeof(ls_time);
     attempt->split_count = split_count;
+    attempt->curr_split = curr_split;
     strcpy(attempt->start_time, timer->start_time);
     ls_run_set_time(attempt->end_time);
 
@@ -257,13 +260,13 @@ ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason)
         goto ls_runs_new_attempt_failed;
     }
 
-    attempt->split_titles = calloc(1, split_count * sizeof(char*));
+    attempt->split_titles = calloc(1, curr_split * sizeof(char*));
     if (attempt->split_titles == NULL) {
         LOG_WARN("unable to allocate `segment_times` for the attempt");
         goto ls_runs_new_attempt_failed;
     }
 
-    for (unsigned int i = 0; i < split_count; ++i) {
+    for (unsigned int i = 0; i < curr_split; ++i) {
         attempt->split_titles[i] = strdup(timer->game->split_titles[i]);
         if (attempt->split_titles[i] == NULL) {
             LOG_WARNF("unable to duplicate `split_titles[%u]` for the attempt", i);
@@ -380,7 +383,7 @@ int ls_runs_save(const ls_runs* snapshot, const ls_game* game)
         // Splits Array
         json_t* splits = json_array();
 
-        for (size_t j = 0; j < attempt->split_count; ++j) {
+        for (size_t j = 0; j < attempt->curr_split; ++j) {
             json_t* split = json_object();
 
             // Title

--- a/src/runs.c
+++ b/src/runs.c
@@ -125,7 +125,11 @@ void ls_runs_release(ls_runs* self)
 static bool ls_attempts_grow(ls_runs* self)
 {
     if (self->size >= MAX_ATTEMPTS_ARRAY_CAPACITTY) {
-        // TODO: Dump this to disk first.
+        LSAppWindow* win = ls_get_main_app_window();
+        if (win && win->game) {
+            ls_runs_save(self, win->game);
+        }
+
         return ls_runs_clear(self);
     }
 

--- a/src/runs.c
+++ b/src/runs.c
@@ -95,7 +95,7 @@ static void ls_attempt_release(ls_attempt* attempt)
     free(attempt->reason);
 
     if (attempt->split_times) {
-        for (unsigned int i = 0; i < attempt->split_count; ++i) {
+        for (unsigned int i = 0; i < attempt->curr_split; ++i) {
             free(attempt->split_titles[i]);
         }
     }
@@ -234,10 +234,10 @@ ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason)
         goto ls_runs_new_attempt_failed;
     }
 
-    const size_t split_count = timer->game->split_count;
+    attempt->split_count = timer->game->split_count;
     const size_t curr_split = timer->curr_split;
     const size_t time_size = curr_split * sizeof(ls_time);
-    attempt->split_count = split_count;
+
     attempt->curr_split = curr_split;
     strcpy(attempt->start_time, timer->start_time);
     ls_run_set_time(attempt->end_time);

--- a/src/runs.c
+++ b/src/runs.c
@@ -267,6 +267,12 @@ ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason)
     }
 
     for (unsigned int i = 0; i < curr_split; ++i) {
+        // Accept empty split titles before trying to allocate memory for them.
+        if (timer->game->split_titles[i] == NULL) {
+            attempt->split_titles[i] = NULL;
+            continue;
+        }
+
         attempt->split_titles[i] = strdup(timer->game->split_titles[i]);
         if (attempt->split_titles[i] == NULL) {
             LOG_WARNF("unable to duplicate `split_titles[%u]` for the attempt", i);
@@ -318,7 +324,7 @@ static json_t* get_or_create_runs_history(const ls_game* game, const char* date,
 
     len = (size_t)written;
     LSAppWindow* win = ls_get_main_app_window();
-    if (!create_default_directory(game->title, path, 0755, win ? GTK_WINDOW(win) : NULL)) {
+    if (!create_default_directory(game->title ? game->title : "runs history directory", path, 0755, win ? GTK_WINDOW(win) : NULL)) {
         return NULL;
     }
 

--- a/src/runs.c
+++ b/src/runs.c
@@ -91,9 +91,14 @@ void ls_runs_release(ls_runs* self)
  */
 static bool grow(ls_runs* self)
 {
+    if (self->size >= MAX_ATTEMPTS_ARRAY_CAPACITTY) {
+        // TODO: Dump this to disk first.
+        return ls_runs_clear(self);
+    }
+
     size_t new_size = self->size + ((size_t)(self->size / 2));
     if (new_size > MAX_ATTEMPTS_ARRAY_CAPACITTY) {
-        // TODO: Dump this to disk and clear capacity.
+        new_size = MAX_ATTEMPTS_ARRAY_CAPACITTY;
     }
 
     size_t old_size = self->size;

--- a/src/runs.c
+++ b/src/runs.c
@@ -89,7 +89,7 @@ void ls_runs_release(ls_runs* self)
  * @param self The runs instance
  * @return bool Whether or not the reallocation succeeded
  */
-static bool grow(ls_runs* self)
+static bool ls_attempts_grow(ls_runs* self)
 {
     if (self->size >= MAX_ATTEMPTS_ARRAY_CAPACITTY) {
         // TODO: Dump this to disk first.
@@ -133,7 +133,7 @@ bool ls_runs_append(ls_runs* self, ls_attempt* attempt)
 {
     self->attempts[self->count++] = attempt;
     if (self->count == self->size) {
-        return grow(self);
+        return ls_attempts_grow(self);
     }
 
     return true;

--- a/src/runs.c
+++ b/src/runs.c
@@ -54,6 +54,14 @@ ls_runs_create_error:
 static void ls_attempt_release(ls_attempt* attempt)
 {
     free(attempt->split_times);
+    free(attempt->segment_times);
+    free(attempt->reason);
+
+    for (unsigned int i = 0; i < attempt->split_count; ++i) {
+        free(attempt->split_titles[i]);
+    }
+
+    free(attempt->split_titles);
     free(attempt);
 }
 
@@ -148,4 +156,70 @@ bool ls_runs_clear(ls_runs* self)
     self->size = INITIAL_ATTEMPTS_ARRAY_SIZE;
     self->count = 0;
     return true;
+}
+
+/**
+ * @brief Creates a new persistent attempt based on the current timer state
+ * and timer completion reason.
+ *
+ * @param timer The current timer instance.
+ * @param reason The reason for the run termination.
+ * @return ls_attempt*
+ */
+ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason)
+{
+    if (reason == NULL) {
+        LOG_WARN("invalid NULL reason provided");
+        return NULL;
+    }
+
+    ls_attempt* attempt = calloc(1, sizeof(ls_attempt));
+    if (attempt == NULL) {
+        LOG_WARN("unable to allocate a new attempt");
+        goto ls_runs_new_attempt_failed;
+    }
+
+    const size_t split_count = timer->game->split_count;
+    size_t time_size = split_count * sizeof(ls_time);
+    attempt->split_count = split_count;
+    attempt->split_times = calloc(1, time_size);
+    if (attempt->split_times == NULL) {
+        LOG_WARN("unable to allocate `split_times` for the attempt");
+        goto ls_runs_new_attempt_failed;
+    }
+
+    attempt->segment_times = calloc(1, time_size);
+    if (attempt->segment_times == NULL) {
+        LOG_WARN("unable to allocate `segment_times` for the attempt");
+        goto ls_runs_new_attempt_failed;
+    }
+
+    attempt->reason = strdup(reason);
+    if (attempt->segment_times == NULL) {
+        LOG_WARN("unable to duplicate `reason` for the attempt");
+        goto ls_runs_new_attempt_failed;
+    }
+
+    attempt->split_titles = calloc(1, split_count * sizeof(char*));
+    if (attempt->segment_times == NULL) {
+        LOG_WARN("unable to allocate `segment_times` for the attempt");
+        goto ls_runs_new_attempt_failed;
+    }
+
+    for (unsigned int i = 0; i < split_count; ++i) {
+        attempt->split_titles[i] = strdup(timer->game->split_titles[i]);
+        if (attempt->segment_times == NULL) {
+            LOG_WARNF("unable to duplicate `split_titles[%u]` for the attempt", i);
+            goto ls_runs_new_attempt_failed;
+        }
+    }
+
+    memcpy(attempt->split_times, timer->split_times, time_size);
+    memcpy(attempt->segment_times, timer->segment_times, time_size);
+    attempt->final_time = ls_timer_get_time(timer, true);
+    return attempt;
+
+ls_runs_new_attempt_failed:
+    ls_attempt_release(attempt);
+    return NULL;
 }

--- a/src/runs.c
+++ b/src/runs.c
@@ -277,23 +277,48 @@ static json_t* get_or_create_runs_history(const ls_game* game, const char* date,
     name = name ? name + 1 : game->path;
     const char* dot = strrchr(name, '.');
 
-    size_t len = strlen(game->path);
+    bool next_to_splits = cfg.libresplit.run_history_next_to_splits.value.b;
+    const char* base = next_to_splits ? game->path : name;
+    size_t len = strlen(base);
     if (dot && dot != name && strcmp(name, "..") != 0) {
-        len = (size_t)(dot - game->path);
+        len = (size_t)(dot - base);
     }
 
-    memcpy(path, game->path, len);
-    path[len] = '\0';
+    int written;
+    if (next_to_splits) {
+        written = snprintf(path, PATH_MAX, "%.*s", (int)len, base);
+    } else {
+        char libresplit_directory[PATH_MAX];
+        get_libresplit_folder_path(libresplit_directory);
+        written = snprintf(path, PATH_MAX, "%s/runs/%.*s", libresplit_directory, (int)len, base);
+    }
 
+    if (written < 0 || written >= PATH_MAX) {
+        if (written < 0) {
+            LOG_ERRF("save game: error determining run histories save location: %s", g_strerror(errno));
+        } else {
+            LOG_ERR("save game: run histories save location is too long");
+        }
+
+        return NULL;
+    }
+
+    len = (size_t)written;
     LSAppWindow* win = ls_get_main_app_window();
     if (!create_default_directory(game->title, path, 0755, win ? GTK_WINDOW(win) : NULL)) {
         return NULL;
     }
 
-    char history_file[FILENAME_MAX + 1];
-    snprintf(history_file, FILENAME_MAX + 1, "/%s.json", date);
-    size_t history_file_len = strlen(history_file);
-    memcpy(path + len, history_file, history_file_len + 1);
+    written = snprintf(path + len, PATH_MAX - len, "/%s.json", date);
+    if (written < 0 || (size_t)written >= PATH_MAX - len) {
+        if (written < 0) {
+            LOG_ERRF("save game: error determining run histories save location: %s", g_strerror(errno));
+        } else {
+            LOG_ERR("save game: run histories save location is too long");
+        }
+
+        return NULL;
+    }
 
     struct stat st = { 0 };
     if (stat(path, &st) == -1) {

--- a/src/runs.h
+++ b/src/runs.h
@@ -7,12 +7,9 @@
  * this would be a truly ridiculous number of runs all in one
  * session without ever saving or closing LibreSplit.
  *
- * Using some conservative assumptions about how many splits are
- * in the run, this would be roughly 1GB of ram usage.
- *
- * This memory is not allocated up front, this would truly require
+ * This memory is not all allocated up front, this would truly require
  * the user to sit there doing *completed* runs for years without ever
- * saving or closing to reach that theoretical 1GB of ram usage.
+ * saving or closing to reach theoreticaly large memory usage.
  */
 #define INITIAL_ATTEMPTS_ARRAY_SIZE 16 // 2^4
 #define MAX_ATTEMPTS_ARRAY_CAPACITTY 524288 // 2^19
@@ -24,7 +21,12 @@
  * that actually goes into the user's saved attempt history.
  */
 typedef struct ls_attempt {
+    char* reason;
+    size_t split_count;
+    char** split_titles;
     ls_time* split_times;
+    ls_time* segment_times;
+    ls_time final_time;
 } ls_attempt;
 
 typedef struct ls_runs {
@@ -37,3 +39,4 @@ int ls_runs_create(ls_runs** attempts);
 void ls_runs_release(ls_runs* attempts);
 bool ls_runs_append(ls_runs* self, ls_attempt* attempt);
 bool ls_runs_clear(ls_runs* self);
+ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason);

--- a/src/runs.h
+++ b/src/runs.h
@@ -23,6 +23,7 @@
 typedef struct ls_attempt {
     char* reason;
     size_t split_count;
+    size_t curr_split;
     char** split_titles;
     ls_time* split_times;
     ls_time* segment_times;

--- a/src/runs.h
+++ b/src/runs.h
@@ -27,12 +27,15 @@ typedef struct ls_attempt {
     ls_time* split_times;
     ls_time* segment_times;
     ls_time final_time;
+    char start_time[64];
+    char end_time[64];
 } ls_attempt;
 
 typedef struct ls_runs {
     ls_attempt** attempts; /**< The attempts array */
     size_t count; /**< The number of attempts in the array i.e. used slots */
     size_t size; /**< The current actual allocation size of the array i.e. total slots */
+    char date[16]; /**< The date from when this session began for the attempts file */
 } ls_runs;
 
 int ls_runs_create(ls_runs** attempts);
@@ -40,3 +43,4 @@ void ls_runs_release(ls_runs* attempts);
 bool ls_runs_append(ls_runs* self, ls_attempt* attempt);
 bool ls_runs_clear(ls_runs* self);
 ls_attempt* ls_runs_new_attempt(ls_timer* timer, const char* reason);
+int ls_runs_save(const ls_runs* snapshot, const ls_game* game);

--- a/src/runs.h
+++ b/src/runs.h
@@ -6,12 +6,11 @@
  * MAX_ATTEMPTS_ARRAY_CAPACITTY ensures that at any given time
  * the maximum amount of memory our in-memory attempts history
  * will be MAX_ATTEMPTS_ARRAY_CAPACITTY * sizeof(ls_attempt)
- * this would be a truly ridiculous number of runs all in one
- * session without ever saving or closing LibreSplit.
  *
  * This memory is not all allocated up front, this would truly require
  * the user to sit there doing *completed* runs for years without ever
- * saving or closing to reach theoreticaly large memory usage.
+ * saving or closing to reach theoreticaly "large" memory usage in the
+ * hundreds of megabytes territory.
  */
 #define INITIAL_ATTEMPTS_ARRAY_SIZE 16 // 2^4
 #define MAX_ATTEMPTS_ARRAY_CAPACITTY 524288 // 2^19

--- a/src/runs.h
+++ b/src/runs.h
@@ -27,13 +27,13 @@ typedef struct ls_attempt {
     ls_time* split_times;
 } ls_attempt;
 
-typedef struct ls_attempts {
+typedef struct ls_runs {
     ls_attempt** attempts; /**< The attempts array */
     size_t count; /**< The number of attempts in the array i.e. used slots */
     size_t size; /**< The current actual allocation size of the array i.e. total slots */
-} ls_attempts;
+} ls_runs;
 
-int ls_attempts_create(ls_attempts** attempts);
-void ls_attempts_release(ls_attempts* attempts);
-bool ls_attempts_append(ls_attempts* self, ls_attempt* attempt);
-bool ls_attempts_clear(ls_attempts* self);
+int ls_runs_create(ls_runs** attempts);
+void ls_runs_release(ls_runs* attempts);
+bool ls_runs_append(ls_runs* self, ls_attempt* attempt);
+bool ls_runs_clear(ls_runs* self);

--- a/src/runs.h
+++ b/src/runs.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "timer.h"
 
 /**

--- a/src/runs.h
+++ b/src/runs.h
@@ -7,10 +7,11 @@
  * the maximum amount of memory our in-memory attempts history
  * will be MAX_ATTEMPTS_ARRAY_CAPACITTY * sizeof(ls_attempt)
  *
- * This memory is not all allocated up front, this would truly require
- * the user to sit there doing *completed* runs for years without ever
- * saving or closing to reach theoreticaly "large" memory usage in the
- * hundreds of megabytes territory.
+ * This memory is not all allocated up front, and the size of ls_attempt
+ * is itself dynamic based on how many splits were completed before reset.
+ * Given that, this would truly require the user to sit there doing *completed*
+ * runs for years without ever saving or closing LibreSplit to reach theoreticaly
+ * "large" memory usage in the hundreds of megabytes territory.
  */
 #define INITIAL_ATTEMPTS_ARRAY_SIZE 16 // 2^4
 #define MAX_ATTEMPTS_ARRAY_CAPACITTY 524288 // 2^19

--- a/src/settings/definitions.c
+++ b/src/settings/definitions.c
@@ -76,6 +76,12 @@ AppConfig cfg = {
             .value.b = true,
             .desc = "Save run history JSON files",
         },
+        .auto_save = {
+            .key = "auto_save",
+            .type = CFG_BOOL,
+            .value.b = true,
+            .desc = "Perform automatic saving after each attempt",
+        },
         .ask_on_gold = {
             .key = "ask_on_gold",
             .type = CFG_BOOL,

--- a/src/settings/definitions.c
+++ b/src/settings/definitions.c
@@ -86,7 +86,7 @@ AppConfig cfg = {
             .key = "ask_on_gold",
             .type = CFG_BOOL,
             .value.b = true,
-            .desc = "Ask before resetting a run with gold splits",
+            .desc = "Ask before quitting with unsaved gold splits",
         },
         .ask_on_worse = {
             .key = "ask_on_worse",

--- a/src/settings/definitions.c
+++ b/src/settings/definitions.c
@@ -76,6 +76,12 @@ AppConfig cfg = {
             .value.b = true,
             .desc = "Save run history JSON files",
         },
+        .run_history_next_to_splits = {
+            .key = "run_history_next_to_splits",
+            .type = CFG_BOOL,
+            .value.b = false,
+            .desc = "Save run history files next to your splits file"
+        },
         .auto_save = {
             .key = "auto_save",
             .type = CFG_BOOL,

--- a/src/settings/definitions.c
+++ b/src/settings/definitions.c
@@ -82,11 +82,11 @@ AppConfig cfg = {
             .value.b = true,
             .desc = "Perform automatic saving after each attempt",
         },
-        .ask_on_gold = {
-            .key = "ask_on_gold",
+        .ask_on_achievement = {
+            .key = "ask_on_achievement",
             .type = CFG_BOOL,
             .value.b = true,
-            .desc = "Ask before quitting with unsaved gold splits",
+            .desc = "Ask before quitting with unsaved an unsaved achievement",
         },
         .ask_on_worse = {
             .key = "ask_on_worse",

--- a/src/settings/definitions.c
+++ b/src/settings/definitions.c
@@ -80,7 +80,7 @@ AppConfig cfg = {
             .key = "run_history_next_to_splits",
             .type = CFG_BOOL,
             .value.b = false,
-            .desc = "Save run history files next to your splits file"
+            .desc = "Save run history files next to your splits file",
         },
         .auto_save = {
             .key = "auto_save",

--- a/src/settings/definitions.h
+++ b/src/settings/definitions.h
@@ -38,6 +38,7 @@ typedef struct LibreSplitConfig {
     ConfigEntry theme_variant;
     ConfigEntry decimals;
     ConfigEntry save_run_history;
+    ConfigEntry run_history_next_to_splits;
     ConfigEntry auto_save;
     ConfigEntry ask_on_achievement;
     ConfigEntry ask_on_worse;

--- a/src/settings/definitions.h
+++ b/src/settings/definitions.h
@@ -38,6 +38,7 @@ typedef struct LibreSplitConfig {
     ConfigEntry theme_variant;
     ConfigEntry decimals;
     ConfigEntry save_run_history;
+    ConfigEntry auto_save;
     ConfigEntry ask_on_gold;
     ConfigEntry ask_on_worse;
 } LibreSplitConfig;

--- a/src/settings/definitions.h
+++ b/src/settings/definitions.h
@@ -39,7 +39,7 @@ typedef struct LibreSplitConfig {
     ConfigEntry decimals;
     ConfigEntry save_run_history;
     ConfigEntry auto_save;
-    ConfigEntry ask_on_gold;
+    ConfigEntry ask_on_achievement;
     ConfigEntry ask_on_worse;
 } LibreSplitConfig;
 

--- a/src/settings/utils.c
+++ b/src/settings/utils.c
@@ -111,7 +111,6 @@ void check_directories(void)
     char auto_splitters_directory[PATH_MAX];
     char themes_directory[PATH_MAX];
     char splits_directory[PATH_MAX];
-    char runs_directory[PATH_MAX];
 
     strcpy(auto_splitters_directory, libresplit_directory);
     strcat(auto_splitters_directory, "/auto-splitters");
@@ -121,9 +120,6 @@ void check_directories(void)
 
     strcpy(splits_directory, libresplit_directory);
     strcat(splits_directory, "/splits");
-
-    strcpy(runs_directory, libresplit_directory);
-    strcat(runs_directory, "/runs");
 
     // Make the libresplit data directory if it doesn't exist
     if (!mkdir_p(libresplit_data_directory, 0755, "LibreSplit Data")) {
@@ -146,9 +142,6 @@ void check_directories(void)
 
     // Make the splits directory if it doesn't exist
     create_default_directory("splits directory", splits_directory, 0755, NULL);
-
-    // Make the runs directory if it doesn't exist
-    create_default_directory("runs directory", runs_directory, 0755, NULL);
 }
 
 /**

--- a/src/settings/utils.c
+++ b/src/settings/utils.c
@@ -111,6 +111,7 @@ void check_directories(void)
     char auto_splitters_directory[PATH_MAX];
     char themes_directory[PATH_MAX];
     char splits_directory[PATH_MAX];
+    char runs_directory[PATH_MAX];
 
     strcpy(auto_splitters_directory, libresplit_directory);
     strcat(auto_splitters_directory, "/auto-splitters");
@@ -120,6 +121,9 @@ void check_directories(void)
 
     strcpy(splits_directory, libresplit_directory);
     strcat(splits_directory, "/splits");
+
+    strcpy(runs_directory, libresplit_directory);
+    strcat(runs_directory, "/runs");
 
     // Make the libresplit data directory if it doesn't exist
     if (!mkdir_p(libresplit_data_directory, 0755, "LibreSplit Data")) {
@@ -142,6 +146,9 @@ void check_directories(void)
 
     // Make the splits directory if it doesn't exist
     create_default_directory("splits directory", splits_directory, 0755, NULL);
+
+    // Make the runs directory if it doesn't exist
+    create_default_directory("runs directory", runs_directory, 0755, NULL);
 }
 
 /**

--- a/src/timer.c
+++ b/src/timer.c
@@ -1348,11 +1348,11 @@ int ls_timer_skip(ls_timer* timer)
  */
 int ls_timer_unsplit(ls_timer* timer)
 {
-    LOG_DEBUG("Undoing a split...");
-    if (timer->curr_split == 0) {
+    if (timer->curr_split == 0 || is_saving()) {
         return 0;
     }
 
+    LOG_DEBUG("Undoing a split...");
     unsigned int curr = --timer->curr_split;
     for (unsigned int i = curr; i < timer->game->split_count; ++i) {
         timer->split_times[i] = timer->game->split_times[i];

--- a/src/timer.c
+++ b/src/timer.c
@@ -766,7 +766,7 @@ bool ls_game_has_achievement(const ls_timer* timer)
         return false;
     }
 
-    if (timer->running && (ls_timer_has_gold_split(timer) || ls_timer_has_rainbow_split(timer))) {
+    if (timer->started && (ls_timer_has_gold_split(timer) || ls_timer_has_rainbow_split(timer))) {
         return true;
     }
 
@@ -1226,6 +1226,7 @@ static void ls_run_record(ls_timer* timer, const char* reason)
         return;
     }
 
+    // TODO: Should we close LibreSplit if this hypothetically fails?
     ls_runs_append(win->runs, attempt);
 }
 
@@ -1299,6 +1300,10 @@ int ls_timer_split(ls_timer* timer)
         ls_game_update_splits((ls_game*)timer->game, timer);
         if (cfg.libresplit.save_run_history.value.b) {
             ls_run_record(timer, "FINISHED");
+        }
+
+        if (cfg.libresplit.auto_save.value.b) {
+            save_game((ls_game*)timer->game);
         }
     }
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -754,7 +754,7 @@ bool ls_timer_has_rainbow_split(const ls_timer* timer)
  * @param path The path to the splits file.
  * @return bool save result
  */
-static bool ls_write_save(json_t* json, const char* path)
+bool ls_write_save(json_t* json, const char* path)
 {
     char* contents = json_dumps(json, JSON_PRESERVE_ORDER | JSON_INDENT(2));
     if (!contents) {
@@ -894,110 +894,6 @@ int ls_game_save(const ls_game* game)
 
     if (!ls_write_save(json, game->path)) {
         error = 1;
-    }
-
-    json_decref(json);
-    return error;
-}
-
-/**
- * Saves the current timer to a run history file.
- *
- * @param timer The current run's timer
- * @param reason Why the run ended
- * @return int Any error code while saving
- */
-int ls_run_save(ls_timer* timer, const char* reason)
-{
-    LOG_DEBUG("Saving historical run file...");
-    ls_time final_time = ls_timer_get_time(timer, true);
-    if (ls_time_lte_zero(final_time))
-        return 0;
-
-    int error = 0;
-
-    // Root JSON Object
-    json_t* json = json_object();
-
-    // Basic Run Info
-    if (timer->game->title) {
-        json_object_set_new(json, "title", json_string(timer->game->title));
-    }
-    if (timer->game->attempt_count) {
-        json_object_set_new(json, "attempt_count", json_integer(timer->game->attempt_count));
-    }
-    if (timer->game->finished_count) {
-        json_object_set_new(json, "finished_count", json_integer(timer->game->finished_count));
-    }
-    json_t* final = json_object();
-    json_time_set(final, &final_time);
-    json_object_set_new(json, "final_time", final);
-    json_object_set_new(json, "reason", json_string(reason));
-
-    // Splits Array
-    json_t* splits = json_array();
-
-    for (unsigned int i = 0; i < timer->game->split_count; i++) {
-        json_t* split = json_object();
-
-        // Title
-        json_object_set_new(split, "title", json_string(timer->game->split_titles[i]));
-
-        // Time
-        if (i < timer->curr_split) {
-            // Check if time is valid, avoids saving time on skipped splits
-            if (is_time_valid(timer->split_times[i].game_time) && is_time_valid(timer->split_times[i].real_time)) {
-                json_t* time = json_object();
-                json_time_set(time, &timer->split_times[i]);
-                json_object_set_new(split, "time", time);
-                // Check if segment time is valid, avoids saving segment time AFTER skipped split
-                if (is_time_valid(timer->segment_times[i].game_time) && is_time_valid(timer->segment_times[i].real_time)) {
-                    json_t* segment = json_object();
-                    json_time_set(segment, &timer->segment_times[i]);
-                    json_object_set_new(split, "segment", segment);
-                } else {
-                    json_object_set_new(split, "segment", json_null());
-                }
-            } else {
-                json_object_set_new(split, "time", json_null());
-                json_object_set_new(split, "segment", json_null());
-            }
-        }
-        json_array_append_new(splits, split);
-    }
-
-    json_object_set_new(json, "splits", splits);
-
-    char path[PATH_MAX];
-    get_libresplit_folder_path(path);
-    strncat(path, "/runs", sizeof(path) - strlen(path) - 1);
-
-    time_t rawtime;
-    struct tm* timeinfo;
-    char time_buf[64];
-    time(&rawtime);
-    timeinfo = localtime(&rawtime);
-    strftime(time_buf, sizeof(time_buf), "%Y-%m-%d_%H-%M-%S", timeinfo);
-
-    char filename[PATH_MAX];
-    int ret = snprintf(filename, sizeof(filename), "%s/run_%s.json", path, time_buf);
-    if (ret < 0 || (size_t)ret >= sizeof(filename)) {
-        LOG_WARN("Error creating run filename. The path may be too long, aborting save.");
-        json_decref(json);
-        return 1;
-    }
-
-    const int json_dump_result = json_dump_file(json, filename, JSON_PRESERVE_ORDER | JSON_INDENT(2));
-    if (json_dump_result) {
-        char* json_dump = json_dumps(json, JSON_PRESERVE_ORDER | JSON_INDENT(2));
-        LOG_WARNF("Error dumping JSON:\n%s", json_dump != NULL ? json_dump : "");
-        LOG_WARNF("Error: '%d'", json_dump_result);
-        LOG_WARNF("Path: %s", filename);
-        error = 1;
-
-        if (json_dump != NULL) {
-            free(json_dump);
-        }
     }
 
     json_decref(json);
@@ -1214,6 +1110,11 @@ void ls_timer_step(ls_timer* timer)
  */
 int ls_timer_start(ls_timer* timer)
 {
+    // Don't allow starts while save operations are happening.
+    if (is_saving()) {
+        return false;
+    }
+
     LOG_DEBUG("Starting timer...");
     // TODO: Allow starting when split_count is 0 for splitless runs, other stuff has to change for this to work (components, timer logic, etc)
     if (timer->curr_split < timer->game->split_count) {
@@ -1221,6 +1122,7 @@ int ls_timer_start(ls_timer* timer)
             ++*timer->attempt_count;
             timer->started = 1;
             atomic_store(&run_started, true);
+            ls_run_set_time(timer->start_time);
         }
         timer->running = true;
         atomic_store(&run_running, true);
@@ -1241,6 +1143,11 @@ static void ls_dialog_save_game(gpointer data)
 
 static void ls_run_record(ls_timer* timer, const char* reason)
 {
+    ls_time final_time = ls_timer_get_time(timer, true);
+    if (ls_time_lte_zero(final_time)) {
+        return;
+    }
+
     LSAppWindow* win = ls_get_main_app_window();
     ls_attempt* attempt = ls_runs_new_attempt(timer, reason);
     if (attempt == NULL) {
@@ -1344,7 +1251,6 @@ int ls_timer_split(ls_timer* timer)
         ls_timer_stop(timer);
         ls_game_update_splits((ls_game*)timer->game, timer);
         if (cfg.libresplit.save_run_history.value.b) {
-            ls_run_save(timer, "FINISHED");
             ls_run_record(timer, "FINISHED");
         }
     }
@@ -1468,7 +1374,6 @@ int ls_timer_reset(ls_timer* timer, ls_game* game)
 
     if (timer->curr_split < timer->game->split_count) {
         if (cfg.libresplit.save_run_history.value.b) {
-            ls_run_save(timer, "RESET");
             ls_run_record(timer, "RESET");
         }
     }
@@ -1549,4 +1454,19 @@ void json_time_set(json_t* ref, const ls_time* time)
     json_object_set_new(ref, "real_time", json_string(str));
     ls_time_string_serialized(str, time->game_time);
     json_object_set_new(ref, "game_time", json_string(str));
+}
+
+/**
+ * @brief Sets the current date and time to a buffer.
+ * The buffer should be at least length 64.
+ *
+ * @param time_buf The char buffer to store the time string in.
+ */
+void ls_run_set_time(char* time_buf)
+{
+    time_t rawtime;
+    struct tm* timeinfo;
+    time(&rawtime);
+    timeinfo = localtime(&rawtime);
+    strftime(time_buf, 64, "%Y-%m-%d_%H-%M-%S", timeinfo);
 }

--- a/src/timer.c
+++ b/src/timer.c
@@ -1296,6 +1296,7 @@ int ls_timer_split(ls_timer* timer)
     if (timer->curr_split == timer->game->split_count) {
         // Increment finished_count
         ++*timer->finished_count;
+        timer->started = 0;
         ls_timer_stop(timer);
         ls_game_update_splits((ls_game*)timer->game, timer);
         if (cfg.libresplit.save_run_history.value.b) {
@@ -1361,6 +1362,7 @@ int ls_timer_unsplit(ls_timer* timer)
         ls_time_clear(&timer->segment_deltas[i]);
     }
     if (timer->curr_split + 1 == timer->game->split_count) {
+        timer->started = 1;
         timer->running = true;
         atomic_store(&run_running, true);
     }

--- a/src/timer.c
+++ b/src/timer.c
@@ -676,6 +676,7 @@ void ls_game_update_splits(ls_game* game, const ls_timer* timer)
             if (split_time && split_time < pb_time) {
                 memcpy(game->split_times, timer->split_times, size);
                 memcpy(game->segment_times, timer->segment_times, size);
+                game->has_unsaved_pb = true;
             }
         }
 
@@ -688,18 +689,30 @@ void ls_game_update_splits(ls_game* game, const ls_timer* timer)
             // update best game time splits
             if (split_time->game_time && split_time->game_time < best_split_time->game_time) {
                 best_split_time->game_time = split_time->game_time;
+                if (game->comparison_method == LS_GAME_TIME) {
+                    game->has_unsaved_rainbow = true;
+                }
             }
             // update best real time splits
             if (split_time->real_time && split_time->real_time < best_split_time->real_time) {
                 best_split_time->real_time = split_time->real_time;
+                if (game->comparison_method == LS_REAL_TIME) {
+                    game->has_unsaved_rainbow = true;
+                }
             }
             // update best game time segments
             if (segment_time->game_time && segment_time->game_time < best_segment_time->game_time) {
                 best_segment_time->game_time = segment_time->game_time;
+                if (game->comparison_method == LS_GAME_TIME) {
+                    game->has_unsaved_gold = true;
+                }
             }
             // update best real time segments
             if (segment_time->real_time && segment_time->real_time < best_segment_time->real_time) {
                 best_segment_time->real_time = segment_time->real_time;
+                if (game->comparison_method == LS_REAL_TIME) {
+                    game->has_unsaved_gold = true;
+                }
             }
         }
     }
@@ -744,6 +757,23 @@ bool ls_timer_has_rainbow_split(const ls_timer* timer)
             return true;
         }
     }
+    return false;
+}
+
+bool ls_game_has_achievement(const ls_timer* timer)
+{
+    if (!timer || !timer->game) {
+        return false;
+    }
+
+    if (timer->running && (ls_timer_has_gold_split(timer) || ls_timer_has_rainbow_split(timer))) {
+        return true;
+    }
+
+    if (timer->game->has_unsaved_pb || timer->game->has_unsaved_gold || timer->game->has_unsaved_rainbow) {
+        return true;
+    }
+
     return false;
 }
 
@@ -898,6 +928,23 @@ int ls_game_save(const ls_game* game)
 
     json_decref(json);
     return error;
+}
+
+void ls_game_saved(void)
+{
+    LSAppWindow* win = ls_get_main_app_window();
+    if (!win) {
+        return;
+    }
+
+    ls_game* game = win->game;
+    if (!game) {
+        return;
+    }
+
+    game->has_unsaved_pb = false;
+    game->has_unsaved_gold = false;
+    game->has_unsaved_rainbow = false;
 }
 
 /**

--- a/src/timer.c
+++ b/src/timer.c
@@ -3,7 +3,11 @@
  * Implementation of the timer
  */
 #include "timer.h"
+#include "gui/app_window.h"
+#include "gui/game.h"
+#include "gui/widgets/dialog.h"
 #include "logging.h"
+#include "runs.h"
 #include "settings/utils.h"
 
 #include "lasr/auto-splitter.h"
@@ -1225,6 +1229,53 @@ int ls_timer_start(ls_timer* timer)
 }
 
 /**
+ * @brief Callback for saving the game to disk
+ * if user requests from a dialog option.
+ *
+ * @param data The `ls_game`
+ */
+static void ls_dialog_save_game(gpointer data)
+{
+    save_game((ls_game*)data);
+}
+
+static void ls_run_record(ls_timer* timer, const char* reason)
+{
+    LSAppWindow* win = ls_get_main_app_window();
+    ls_attempt* attempt = ls_runs_new_attempt(timer, reason);
+    if (attempt == NULL) {
+        const LSDialogOption options[] = {
+            {
+                .label = "_Yes",
+                .callback = ls_dialog_save_game,
+                .is_cancel = FALSE,
+                .is_default = TRUE,
+            },
+            {
+                .label = "_No",
+                .callback = NULL,
+                .is_cancel = TRUE,
+                .is_default = FALSE,
+            }
+        };
+
+        const LSDialogIcon icon = {
+            .source = "dialog-question",
+            .type = LS_DIALOG_ICON_NAME,
+        };
+
+        ls_dialog_open(GTK_WINDOW(win),
+            "LibreSplit",
+            "Save Failed",
+            "We could not record your game in memory, would you like to save your history now?",
+            &icon, options, G_N_ELEMENTS(options), win->game, NULL);
+        return;
+    }
+
+    ls_runs_append(win->runs, attempt);
+}
+
+/**
  * Performs a split
  *
  * @param timer The timer instance
@@ -1294,6 +1345,7 @@ int ls_timer_split(ls_timer* timer)
         ls_game_update_splits((ls_game*)timer->game, timer);
         if (cfg.libresplit.save_run_history.value.b) {
             ls_run_save(timer, "FINISHED");
+            ls_run_record(timer, "FINISHED");
         }
     }
 
@@ -1417,6 +1469,7 @@ int ls_timer_reset(ls_timer* timer, ls_game* game)
     if (timer->curr_split < timer->game->split_count) {
         if (cfg.libresplit.save_run_history.value.b) {
             ls_run_save(timer, "RESET");
+            ls_run_record(timer, "RESET");
         }
     }
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -930,14 +930,8 @@ int ls_game_save(const ls_game* game)
     return error;
 }
 
-void ls_game_saved(void)
+void ls_game_saved(ls_game* game)
 {
-    LSAppWindow* win = ls_get_main_app_window();
-    if (!win) {
-        return;
-    }
-
-    ls_game* game = win->game;
     if (!game) {
         return;
     }

--- a/src/timer.c
+++ b/src/timer.c
@@ -1001,7 +1001,7 @@ int ls_run_save(ls_timer* timer, const char* reason)
 }
 
 /**
- * Frees all the timer information, but not itself
+ * Frees all the timer information
  *
  * @param timer The timer instance
  */
@@ -1069,7 +1069,7 @@ static void reset_timer(ls_timer* timer)
 /**
  * Creates a timer instance linked to a game instance, allocating necessary memory
  *
- * @param timer_ptr Apointer to where the allocated timer instance should be stored
+ * @param timer_ptr A pointer to where the allocated timer instance should be stored
  * @param game The game instance to link the timer to
  * @return Whether the timer creation had an error or not
  */

--- a/src/timer.h
+++ b/src/timer.h
@@ -90,6 +90,7 @@ typedef struct ls_timer {
     long long last_tick; // This NEEDS to be here for resetting
     int* attempt_count;
     int* finished_count;
+    char start_time[64];
 } ls_timer;
 
 extern atomic_bool run_started;
@@ -128,6 +129,8 @@ bool ls_timer_has_gold_split(const ls_timer* timer);
 
 bool ls_timer_has_rainbow_split(const ls_timer* timer);
 
+bool ls_write_save(json_t* json, const char* path);
+
 int ls_game_save(const ls_game* game);
 
 void ls_game_release(ls_game* game);
@@ -159,3 +162,5 @@ void ls_timer_cancel(ls_timer* timer);
 void json_time_get(const json_t* ref, ls_time* time);
 
 void json_time_set(json_t* ref, const ls_time* time);
+
+void ls_run_set_time(char* time_buf);

--- a/src/timer.h
+++ b/src/timer.h
@@ -138,7 +138,7 @@ bool ls_write_save(json_t* json, const char* path);
 
 int ls_game_save(const ls_game* game);
 
-void ls_game_saved(void);
+void ls_game_saved(ls_game* game);
 
 void ls_game_release(ls_game* game);
 

--- a/src/timer.h
+++ b/src/timer.h
@@ -62,6 +62,9 @@ typedef struct ls_game {
     ls_time* segment_times;
     ls_time* best_splits;
     ls_time* best_segments;
+    bool has_unsaved_pb;
+    bool has_unsaved_gold;
+    bool has_unsaved_rainbow;
 } ls_game;
 
 /**
@@ -129,9 +132,13 @@ bool ls_timer_has_gold_split(const ls_timer* timer);
 
 bool ls_timer_has_rainbow_split(const ls_timer* timer);
 
+bool ls_game_has_achievement(const ls_timer* timer);
+
 bool ls_write_save(json_t* json, const char* path);
 
 int ls_game_save(const ls_game* game);
+
+void ls_game_saved(void);
 
 void ls_game_release(ls_game* game);
 


### PR DESCRIPTION
The goal of this PR is to add better handling for splits and attempts history.

At present there are several issues with how we handle splits, runs, attempts that sort of thing. Those are:

- Runs save instantly after a reset or a finishes run. This might be undesirable as the user might not want whatever happen to actually overwrite their splits file.
- An attempt is immediately recorded after it's reset/finished. (See above)
- An attempt gets written to its own file for each attempt. That creates tens of thousands of files over the life of a speedrunner's attempts and is quite messy...
- Attempts history is a very loose concept in general in that there's no real association with your splits and it feels almost like a second class citizen feature. I'm not sure a typical user would even be aware that attempts get recorded without seeing the setting (on by default) and even then they won't really know where they are.
- All of the issues above mean I think we have some pretty loose edge cases for achievements loss. (i.e. new golds/pb etc)
- It also means that there's no easy way for use to have a converter that keeps split history without having to give the user instructions on where to put files. (i.e. the converter should allow you to just download a zip, extract it anywhere and the splits file knows where your run history is)

In order to solve for the problems above I've made the following changes:

- Added a setting that allows the user to disable auto saves. With autosaves disabled, only manually saving via context menu will write new splits, runs etc to disk.
- Added a setting that allows the user to prefer saving runs history next to splits file instead of in the default runs directory
  - i.e. if you have `game-123.json` at `/home/user/Desktop` then your run history files will be stored in `/home/user/Desktop/game-123/*`
- Attempts now get stored to a `date.json` file where `date` means the date of when the current splits file was opened (i.e. the play session for that game) in `YYYY-MM-DD` format.
  - This file is a root level array, each attempt gets appended to this array instead of creating a new file for every single attempt.
  - The date only gets updated when you open a splits file, so if you play some game then close it then open it again it will continue appending to that same date file. If you play in one session for 2 days straight without closing, it will also append to the same date from (i.e. tomorrow's attempts are still in today's session since the session never ended)
-  Attempts only get written when a save occurs (via user manual save or autosave)
- Each attempt is stored in memory until it gets saved. (allowing us to not have to force autosaves since allowing the user to choose if/when they want to save)
- Game now keeps track of achievements so we can warn players of unsaved achievements when they try to close their splits or libresplit.
- Some misc improvements
  - error handling
  - attempt file saving goes through the new atomic file save function
  - main window is a singleton now so we can access it better
  - update settings doc
- Changed the lsdialogcallback signature to be compatible to gsourcefunc so that callbacks can be queue'd either to the main thread via `g_idle_add` or to a dialog window.
- Changed the default directory helpers for libresplit's config/data directories to use GLib's implementation which is safer and easier to use. (The paths do not change)
  - https://docs.gtk.org/glib/func.get_user_data_dir.html
  - https://docs.gtk.org/glib/func.get_user_config_dir.html
- Probably some other stuff I'm forgetting.

This has ballooned quite a bit more than I intended... In particular it has become necessary to prevent certain limitations of LibreSplit running under two instances at once by preventing LibreSplit from being able to open more than once instance. This will hopefully be just a temporary measure.